### PR TITLE
Run Actor Trigger

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,25 @@ Once you have your connector set up, follow this development cycle:
    - Update the connector again using the `pac connector update` command
    - Repeat the testing process
 
+## Triggers
+
+### Actor Run Finished Trigger
+
+Use the "Actor Run Finished" trigger to automatically execute your Power Automate flow when a specific Apify Actor run completes with a selected status.
+
+- **Authentication**: Use Apify API Key or OAuth 2.0 (scopes: `profile`, `full_api_access`).
+- **Headers**: All requests include `x-apify-integration-platform: microsoft-power-automate`.
+- **Inputs**:
+  - `Actor Scope`: Choose between "Recently used Actors" or "From Store" (Apify Store actors).
+  - `Actor`: Dynamic dropdown populated with actors based on the selected scope.
+  - `Trigger On`: Select which run statuses should trigger the flow (SUCCEEDED, FAILED, TIMED_OUT, ABORTED).
+- **Output**: Webhook payload containing detailed information about the completed actor run.
+
+How it works:
+- Actor dropdown is populated via `GET /v2/acts` (for recent actors) or via `GET /v2/store` store API (for store actors).
+- The trigger creates a webhook via `POST /v2/webhooks` that subscribes to actor run events.
+- When the selected actor finishes with one of the specified statuses, Apify sends a webhook payload to Power Automate.
+
 ## Actions 
 
 ### Get Dataset Items Action
@@ -259,8 +278,8 @@ Use the "Run Actor" action to start an Apify Actor run.
 
 - Authentication: Use Apify API Key or OAuth 2.0 (scopes: `profile`, `full_api_access`).
 - Headers: All requests include `x-apify-integration-platform: microsoft-power-automate`.
-- Actor Source (`actorScope`): Choose "My Actors" or "From Store".
-  - If "My Actors": pick from `Actor` populated by your account Actors.
+- Actor Source (`actorScope`): Choose "Recently used Actors" or "From Store".
+  - If "Recently used Actors": pick from `Actor` populated by your account Actors.
   - If "From Store": pick from `Actor` populated by Apify Store (limit 1000).
 - Input Body (`inputBody`): Provide JSON for the Actor input.
 - Optional query params:

--- a/apiDefinition.swagger.json
+++ b/apiDefinition.swagger.json
@@ -1292,109 +1292,135 @@
       "properties": {
         "id": {
           "type": "string",
-          "x-ms-summary": "Actor Run ID"
+          "x-ms-summary": "Actor Run ID",
+          "description": "Unique identifier of the Actor run."
         },
         "actId": {
           "type": "string",
-          "x-ms-summary": "Actor ID"
+          "x-ms-summary": "Actor ID",
+          "description": "Unique identifier of the Actor that was executed."
         },
         "userId": {
           "type": "string",
-          "x-ms-summary": "User ID"
+          "x-ms-summary": "User ID",
+          "description": "Unique identifier of the user who owns the Actor run."
         },
         "actorTaskId": {
           "type": "string",
-          "x-ms-summary": "Actor Task ID"
+          "x-ms-summary": "Actor Task ID",
+          "description": "Unique identifier of the Actor task (if the run was started from a task)."
         },
         "startedAt": {
           "type": "string",
           "format": "date-time",
-          "x-ms-summary": "Started At"
+          "x-ms-summary": "Started At",
+          "description": "Timestamp when the Actor run started."
         },
         "finishedAt": {
           "type": "string",
           "format": "date-time",
-          "x-ms-summary": "Finished At"
+          "x-ms-summary": "Finished At",
+          "description": "Timestamp when the Actor run finished."
         },
         "status": {
           "type": "string",
-          "x-ms-summary": "Status"
+          "x-ms-summary": "Status",
+          "description": "Status of the Actor run (e.g., SUCCEEDED, FAILED, RUNNING, ABORTED)."
         },
         "statusMessage": {
           "type": "string",
-          "x-ms-summary": "Status Message"
+          "x-ms-summary": "Status Message",
+          "description": "Detailed status message from the Actor run, including processing summary and results."
         },
         "isStatusMessageTerminal": {
           "type": "boolean",
-          "x-ms-summary": "Is Status Message Terminal"
+          "x-ms-summary": "Is Status Message Terminal",
+          "description": "Whether the status message is terminal (final) or may change during the run."
         },
         "meta": {
           "type": "object",
-          "x-ms-summary": "Metadata"
+          "x-ms-summary": "Metadata",
+          "description": "Additional metadata about the Actor run, including origin and user agent information."
         },
         "pricingInfo": {
           "type": "object",
-          "x-ms-summary": "Pricing Info"
+          "x-ms-summary": "Pricing Info",
+          "description": "Detailed pricing information including pricing model, events, and cost breakdown."
         },
         "stats": {
           "type": "object",
-          "x-ms-summary": "Stats"
+          "x-ms-summary": "Stats",
+          "description": "Performance statistics including runtime, memory usage, CPU usage, and network traffic."
         },
         "chargedEventCount": {
           "type": "object",
-          "x-ms-summary": "Charged Event Count"
+          "x-ms-summary": "Charged Event Count",
+          "description": "Count of billable events that occurred during the Actor run."
         },
         "options": {
           "type": "object",
-          "x-ms-summary": "Options"
+          "x-ms-summary": "Options",
+          "description": "Configuration options used for the Actor run (memory, timeout, build version, etc.)."
         },
         "buildId": {
           "type": "string",
-          "x-ms-summary": "Build ID"
+          "x-ms-summary": "Build ID",
+          "description": "Unique identifier of the Actor build used for this run."
         },
         "exitCode": {
           "type": "number",
-          "x-ms-summary": "Exit Code"
+          "x-ms-summary": "Exit Code",
+          "description": "Exit code returned by the Actor process (0 indicates success)."
         },
         "defaultKeyValueStoreId": {
           "type": "string",
-          "x-ms-summary": "Default KV Store ID"
+          "x-ms-summary": "Default KV Store ID",
+          "description": "Unique identifier of the default key-value store associated with this run."
         },
         "defaultDatasetId": {
           "type": "string",
-          "x-ms-summary": "Default Dataset ID"
+          "x-ms-summary": "Default Dataset ID",
+          "description": "Unique identifier of the default dataset where the Actor stored its results."
         },
         "defaultRequestQueueId": {
           "type": "string",
-          "x-ms-summary": "Default Request Queue ID"
+          "x-ms-summary": "Default Request Queue ID",
+          "description": "Unique identifier of the default request queue used by the Actor."
         },
         "buildNumber": {
           "type": "string",
-          "x-ms-summary": "Build Number"
+          "x-ms-summary": "Build Number",
+          "description": "Build number of the Actor version used for this run."
         },
         "containerUrl": {
           "type": "string",
-          "x-ms-summary": "Container URL"
+          "x-ms-summary": "Container URL",
+          "description": "URL of the container where the Actor run was executed."
         },
         "isContainerServerReady": {
           "type": "boolean",
-          "x-ms-summary": "Is Container Server Ready"
+          "x-ms-summary": "Is Container Server Ready",
+          "description": "Whether the container server is ready and accessible."
         },
         "gitBranchName": {
           "type": "string",
-          "x-ms-summary": "Git Branch Name"
+          "x-ms-summary": "Git Branch Name",
+          "description": "Name of the Git branch used for this Actor run (if applicable)."
         },
         "usage": {
           "type": "object",
-          "x-ms-summary": "Usage"
+          "x-ms-summary": "Usage",
+          "description": "Detailed usage information including compute units and resource consumption."
         },
         "usageTotalUsd": {
           "type": "number",
-          "x-ms-summary": "Usage Total USD"
+          "x-ms-summary": "Usage Total USD",
+          "description": "Total cost of the Actor run in USD."
         },
         "usageUsd": {
           "type": "number",
-          "x-ms-summary": "Usage USD"
+          "x-ms-summary": "Usage USD",
+          "description": "Usage cost in USD for this specific run."
         }
       }
     },
@@ -1412,6 +1438,10 @@
             "actorRunId": { "type": "string", "description": "ID of the specific Actor run that triggered the event." }
           },
           "additionalProperties": true
+        },
+        "resource": {
+          "description": "Detailed information about the Actor run resource.",
+          "$ref": "#/definitions/ActorRunResponse"
         }
       },
       "additionalProperties": true

--- a/apiDefinition.swagger.json
+++ b/apiDefinition.swagger.json
@@ -1429,7 +1429,16 @@
       "properties": {
         "userId": { "type": "string", "description": "ID of the user who owns the resource associated with the event." },
         "createdAt": { "type": "string", "format": "date-time", "description": "The timestamp when the event occurred." },
-        "eventType": { "type": "string", "description": "The type of the event (e.g., ACTOR.RUN.SUCCEEDED)." },
+        "eventType": { 
+          "type": "string", 
+          "description": "The type of the event that triggered the webhook. (e.g., ACTOR.RUN.SUCCEEDED)",
+          "enum": [
+            "ACTOR.RUN.SUCCEEDED",
+            "ACTOR.RUN.FAILED",
+            "ACTOR.RUN.TIMED_OUT",
+            "ACTOR.RUN.ABORTED"
+          ]
+        },
         "eventData": {
           "type": "object",
           "description": "An object containing event-specific data.",

--- a/apiDefinition.swagger.json
+++ b/apiDefinition.swagger.json
@@ -571,6 +571,7 @@
           }
         ],
         "responses": {
+          "200": { "description": "OK" },
           "204": { "description": "No Content" },
           "default": { "$ref": "#/responses/ErrorResponse" }
         }

--- a/apiDefinition.swagger.json
+++ b/apiDefinition.swagger.json
@@ -25,23 +25,33 @@
   "produces": [
     "application/json"
   ],
-  "x-ms-policy": [
-    {
-    "type": "set-header",
-    "header": "x-apify-integration-platform",
-    "value": "power-automate"
-  }],
   "securityDefinitions": {
     "api_key": {
       "type": "apiKey",
       "in": "header",
       "name": "Authorization",
       "description": "API Token for authenticating with the Apify API. Get it at https://console.apify.com/settings/integrations"
+    },
+    "oauth2_auth": {
+      "type": "oauth2",
+      "flow": "accessCode",
+      "authorizationUrl": "https://console.apify.com/authorize/oauth",
+      "tokenUrl": "https://console-backend.apify.com/oauth/apps/token",
+      "scopes": {
+        "profile": "Access to user profile",
+        "full_api_access": "Full access to Apify API"
+      }
     }
   },
   "security": [
     {
       "api_key": []
+    },
+    {
+      "oauth2_auth": [
+        "profile",
+        "full_api_access"
+      ]
     }
   ],
   "x-ms-connector-metadata": [
@@ -58,8 +68,547 @@
       "propertyValue": "Data;AI"
     }
   ],
-  "paths": {},
+  "x-ms-capabilities": {
+    "testConnection": {
+      "operationId": "GetUserInfo"
+    }
+  },
+  "paths": {
+    "/users/me": {
+      "get": {
+        "parameters": [
+          {
+            "$ref": "#/parameters/IntegrationPlatformHeader"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "User information retrieved successfully",
+            "schema": {
+              "$ref": "#/definitions/UserResponse"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/ErrorResponse"
+          }
+        },
+        "summary": "Get User Information",
+        "description": "Returns information about the current user account, including both public and private information.",
+        "operationId": "GetUserInfo",
+        "x-ms-visibility": "internal",
+        "x-ms-summary": "Get User Information",
+        "tags": [
+          "Users"
+        ]
+      }
+    },
+    "/acts": {
+      "get": {
+        "summary": "List My Actors (for dropdown)",
+        "description": "Fetches a list of the user's Actors.",
+        "operationId": "ListMyActors",
+        "x-ms-visibility": "internal",
+        "tags": [
+          "Actors"
+        ],
+        "parameters": [
+          {
+            "name": "actor_scope",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "enum": [
+              "MyActors",
+              "StoreActors"
+            ],
+            "description": "Only used by the connector UI to trigger list refresh when scope changes.",
+            "x-ms-visibility": "internal"
+          },
+          {
+            "$ref": "#/parameters/IntegrationPlatformHeader"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "data": {
+                  "type": "object",
+                  "properties": {
+                    "total": { "type": "integer", "format": "int32" },
+                    "count": { "type": "integer", "format": "int32" },
+                    "offset": { "type": "integer", "format": "int32" },
+                    "limit": { "type": "integer", "format": "int32" },
+                    "desc": { "type": "boolean" },
+                    "items": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": { "type": "string" },
+                          "createdAt": { "type": "string" },
+                          "modifiedAt": { "type": "string" },
+                          "name": { "type": "string" },
+                          "username": { "type": "string" },
+                          "title": { "type": "string" },
+                          "stats": {
+                            "type": "object",
+                            "properties": {
+                              "totalRuns": { "type": "integer", "format": "int32" },
+                              "lastRunStartedAt": { "type": "string" }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              "additionalProperties": true
+            }
+          },
+          "default": {
+            "$ref": "#/responses/ErrorResponse"
+          }
+        }
+      }
+    },
+    "/store": {
+      "get": {
+        "summary": "List Store Actors (for dropdown)",
+        "description": "Fetches a list of Actors from the Apify Store.",
+        "operationId": "ListStoreActors",
+        "x-ms-visibility": "internal",
+        "tags": [
+          "Actors"
+        ],
+        "parameters": [
+          {
+            "name": "actor_scope",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "enum": [
+              "MyActors",
+              "StoreActors"
+            ],
+            "description": "Only used by the connector UI to trigger list refresh when scope changes.",
+            "x-ms-visibility": "internal"
+          },
+          {
+            "$ref": "#/parameters/IntegrationPlatformHeader"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "type": "integer",
+            "required": false,
+            "default": 50,
+            "x-ms-summary": "Maximum number of Actors to return"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "data": {
+                  "type": "object",
+                  "properties": {
+                    "items": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "title": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/responses/ErrorResponse"
+          }
+        }
+      }
+    },
+    "/actors/dropdown": {
+      "get": {
+        "summary": "List Actors (dropdown)",
+        "description": "Fetches a list of Actors from My Actors or Apify Store based on scope for dropdown selection.",
+        "operationId": "ListActorsDropdown",
+        "x-ms-visibility": "internal",
+        "tags": [
+          "Actors"
+        ],
+        "parameters": [
+          {
+            "name": "actor_scope",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "enum": [
+              "MyActors",
+              "StoreActors"
+            ],
+            "description": "Select source of Actors: your own or the Apify Store.",
+            "x-ms-visibility": "internal"
+          },
+          {
+            "$ref": "#/parameters/IntegrationPlatformHeader"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "type": "integer",
+            "required": false,
+            "default": 50,
+            "x-ms-summary": "Maximum number of Actors to return"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "data": {
+                  "type": "object",
+                  "properties": {
+                    "items": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": { "type": "string" },
+                          "title": { "type": "string" }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/responses/ErrorResponse"
+          }
+        }
+      }
+    },
+    "/acts/{actorId}/runs": {
+      "post": {
+        "summary": "Run Actor",
+        "description": "Runs an Actor and immediately returns without waiting for the run to finish. To wait for the run to finish, use the waitForFinish query parameter. See docs: https://docs.apify.com/api/v2/act-runs-post",
+        "operationId": "RunActor",
+        "x-ms-summary": "Run Actor",
+        "x-ms-visibility": "important",
+        "tags": [
+          "Actors"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/parameters/IntegrationPlatformHeader"
+          },
+          {
+            "name": "actorId",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "Actor identifier to run. For My Actors supply Actor ID; for Store supply Actor name.",
+            "x-ms-summary": "Actor",
+            "x-ms-dynamic-values": {
+              "operationId": "ListActorsDropdown",
+              "value-collection": "data/items",
+              "value-path": "id",
+              "value-title": "title",
+              "parameters": {
+                "actor_scope": { "parameter": "actor_scope" },
+                "limit": 50
+              }
+            },
+            "x-ms-visibility": "important"
+          },
+          {
+            "name": "actor_scope",
+            "description": "Actor can be either yours or from the Apify Store.",
+            "default": "MyActors",
+            "in": "query",
+            "required": true,
+            "type": "string",
+            "format": "",
+            "x-ms-summary": "Actor Source",
+            "enum": [
+              "MyActors",
+              "StoreActors"
+            ],
+            "x-ms-enum-display-name": [
+              "My Actors",
+              "From Store"
+            ]
+          },
+          {
+            "name": "build",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "Specifies the Actor build to run. It can be either a build tag or build number. By default, the run uses the build specified in the default run configuration for the Actor (typically latest).",
+            "x-ms-summary": "Build"
+          },
+          {
+            "name": "timeout",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "description": "Optional timeout for the run, in seconds. By default, the run uses a timeout specified in the default run configuration for the Actor.",
+            "x-ms-summary": "Timeout (seconds)"
+          },
+          {
+            "name": "memory",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "description": "Memory limit for the run, in megabytes. The amount of memory can be set to a power of 2 with a minimum of 128. By default, the run uses a memory limit specified in the default run configuration for the Actor.",
+            "x-ms-summary": "Memory (MB)",
+            "enum": [
+              512,
+              1024,
+              2048,
+              4096,
+              8192,
+              16384
+            ]
+          },
+          {
+            "name": "waitForFinish",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "x-ms-summary": "Wait for Finish (seconds)",
+            "description": "The maximum number of seconds the server waits for the run to finish. By default, it is 0, the maximum value is 60. If the run finishes in time then the returned run object will have a terminal status (e.g. SUCCEEDED), otherwise it will have a transitional status (e.g. RUNNING).",
+            "maximum": 60,
+            "default": 0
+          },
+          {
+            "name": "input_body",
+            "in": "body",
+            "required": true,
+            "description": "Raw JSON object passed as INPUT to the Actor.",
+            "x-ms-textarea": true,
+            "x-ms-summary": "Input Body",
+            "schema": {
+              "type": "object",
+              "description": "Raw JSON object passed as INPUT to the Actor"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Actor run created",
+            "schema": {
+              "$ref": "#/definitions/ActorRunResponse"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/ErrorResponse"
+          }
+        }
+      }
+    },
+    "/webhooks": {
+      "x-ms-notification-content": {
+        "description": "Payload received from Apify when the webhook fires",
+        "schema": { "$ref": "#/definitions/WebhookPayload" }
+      },
+      "post": {
+        "summary": "Actor Run Finished",
+        "description": "Creates a webhook to subscribe to Actor run events. Triggers when the selected Actor run finishes with a specific status. See docs: https://docs.apify.com/api/v2/webhooks-post",
+        "operationId": "ActorRunFinishedTrigger",
+        "x-ms-trigger": "single",
+        "tags": [
+          "Webhooks"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/parameters/IntegrationPlatformHeader"
+          },
+          {
+            "name": "actor_scope",
+            "in": "query",
+            "required": true,
+            "type": "string",
+            "default": "MyActors",
+            "x-ms-summary": "Actor Source",
+            "enum": ["MyActors", "StoreActors"],
+            "x-ms-enum-display-name": ["My Actors", "From Store"]
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "properties": {
+                "requestUrl": { "type": "string", "x-ms-notification-url": true },
+                "eventTypes": {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "x-ms-enum-values": [
+                      { "value": "ACTOR.RUN.SUCCEEDED", "displayName": "SUCCEEDED" },
+                      { "value": "ACTOR.RUN.FAILED", "displayName": "FAILED" },
+                      { "value": "ACTOR.RUN.TIMED_OUT", "displayName": "TIMED_OUT" },
+                      { "value": "ACTOR.RUN.ABORTED", "displayName": "ABORTED" }
+                    ]
+                  }
+                },
+                "condition": {
+                  "type": "object",
+                  "properties": {
+                    "actorId": {
+                      "type": "string",
+                      "x-ms-summary": "Actor",
+                      "x-ms-dynamic-values": {
+                        "operationId": "ListActorsDropdown",
+                        "value-collection": "data/items",
+                        "value-path": "id",
+                        "value-title": "title",
+                        "parameters": {
+                          "actor_scope": { "parameter": "actor_scope" },
+                          "limit": 50
+                        }
+                      }
+                    }
+                  }
+                },
+                "idempotencyKey": { "type": "string" },
+                "payloadTemplate": { "type": "string" },
+                "shouldInterpolateStrings": { "type": "boolean" }
+              },
+              "required": ["requestUrl", "eventTypes", "condition"]
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Created",
+            "schema": { "$ref": "#/definitions/WebhookCreateResponse" }
+          },
+          "default": { "$ref": "#/responses/ErrorResponse" }
+        }
+      }
+    }
+    ,
+    "/webhooks/{webhookId}": {
+      "delete": {
+        "summary": "Delete Actor Webhook (for trigger)",
+        "description": "Deletes an existing webhook subscription.",
+        "operationId": "DeleteActorWebhook",
+        "x-ms-visibility": "internal",
+        "tags": [
+          "Webhooks"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/parameters/IntegrationPlatformHeader"
+          },
+          {
+            "name": "webhookId",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "x-ms-url-encoding": "single"
+          }
+        ],
+        "responses": {
+          "204": { "description": "No Content" },
+          "default": { "$ref": "#/responses/ErrorResponse" }
+        }
+      }
+    }
+    
+  },
   "definitions": {
+    "UserResponse": {
+      "type": "object",
+      "x-ms-summary": "Represents information about the authenticated Apify user.",
+      "properties": {
+        "id": {
+          "type": "string",
+          "x-ms-summary": "User ID"
+        },
+        "username": {
+          "type": "string",
+          "x-ms-summary": "Username"
+        },
+        "email": {
+          "type": "string",
+          "x-ms-summary": "Email"
+        },
+        "name": {
+          "type": "string",
+          "x-ms-summary": "Full Name"
+        },
+        "createdAt": {
+          "type": "string",
+          "format": "date-time",
+          "x-ms-summary": "Created At"
+        },
+        "subscription": {
+          "type": "object",
+          "x-ms-summary": "Subscription",
+          "properties": {
+            "plan": {
+              "type": "string",
+              "x-ms-summary": "Plan"
+            },
+            "planId": {
+              "type": "string",
+              "x-ms-summary": "Plan ID"
+            },
+            "isActive": {
+              "type": "boolean",
+              "x-ms-summary": "Is Active"
+            }
+          }
+        },
+        "profile": {
+          "type": "object",
+          "properties": {
+            "pictureUrl": {
+              "type": "string",
+              "x-ms-summary": "Profile Picture URL"
+            },
+            "githubUsername": {
+              "type": "string",
+              "x-ms-summary": "GitHub Username"
+            },
+            "websiteUrl": {
+              "type": "string",
+              "x-ms-summary": "Website URL"
+            },
+            "bio": {
+              "type": "string",
+              "x-ms-summary": "User's bio"
+            }
+          }
+        }
+      }
+    },
     "ErrorResponse": {
       "type": "object",
       "properties": {
@@ -80,8 +629,163 @@
         }
       }
     }
+    ,
+    "ActorRunResponse": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "x-ms-summary": "Actor Run ID"
+        },
+        "actId": {
+          "type": "string",
+          "x-ms-summary": "Actor ID"
+        },
+        "userId": {
+          "type": "string",
+          "x-ms-summary": "User ID"
+        },
+        "actorTaskId": {
+          "type": "string",
+          "x-ms-summary": "Actor Task ID"
+        },
+        "startedAt": {
+          "type": "string",
+          "format": "date-time",
+          "x-ms-summary": "Started At"
+        },
+        "finishedAt": {
+          "type": "string",
+          "format": "date-time",
+          "x-ms-summary": "Finished At"
+        },
+        "status": {
+          "type": "string",
+          "x-ms-summary": "Status"
+        },
+        "statusMessage": {
+          "type": "string",
+          "x-ms-summary": "Status Message"
+        },
+        "isStatusMessageTerminal": {
+          "type": "boolean",
+          "x-ms-summary": "Is Status Message Terminal"
+        },
+        "meta": {
+          "type": "object",
+          "x-ms-summary": "Metadata"
+        },
+        "pricingInfo": {
+          "type": "object",
+          "x-ms-summary": "Pricing Info"
+        },
+        "stats": {
+          "type": "object",
+          "x-ms-summary": "Stats"
+        },
+        "chargedEventCount": {
+          "type": "object",
+          "x-ms-summary": "Charged Event Count"
+        },
+        "options": {
+          "type": "object",
+          "x-ms-summary": "Options"
+        },
+        "buildId": {
+          "type": "string",
+          "x-ms-summary": "Build ID"
+        },
+        "exitCode": {
+          "type": "number",
+          "x-ms-summary": "Exit Code"
+        },
+        "defaultKeyValueStoreId": {
+          "type": "string",
+          "x-ms-summary": "Default KV Store ID"
+        },
+        "defaultDatasetId": {
+          "type": "string",
+          "x-ms-summary": "Default Dataset ID"
+        },
+        "defaultRequestQueueId": {
+          "type": "string",
+          "x-ms-summary": "Default Request Queue ID"
+        },
+        "buildNumber": {
+          "type": "string",
+          "x-ms-summary": "Build Number"
+        },
+        "containerUrl": {
+          "type": "string",
+          "x-ms-summary": "Container URL"
+        },
+        "isContainerServerReady": {
+          "type": "boolean",
+          "x-ms-summary": "Is Container Server Ready"
+        },
+        "gitBranchName": {
+          "type": "string",
+          "x-ms-summary": "Git Branch Name"
+        },
+        "usage": {
+          "type": "object",
+          "x-ms-summary": "Usage"
+        },
+        "usageTotalUsd": {
+          "type": "number",
+          "x-ms-summary": "Usage Total USD"
+        },
+        "usageUsd": {
+          "type": "number",
+          "x-ms-summary": "Usage USD"
+        }
+      }
+    }
+    ,
+    "WebhookPayload": {
+      "type": "object",
+      "properties": {
+        "userId": { "type": "string", "description": "ID of the user who owns the resource associated with the event." },
+        "createdAt": { "type": "string", "format": "date-time", "description": "The timestamp when the event occurred." },
+        "eventType": { "type": "string", "description": "The type of the event (e.g., ACTOR.RUN.SUCCEEDED)." },
+        "eventData": {
+          "type": "object",
+          "description": "An object containing event-specific data.",
+          "properties": {
+            "actorId": { "type": "string", "description": "ID of the triggering Actor." },
+            "actorRunId": { "type": "string", "description": "ID of the specific Actor run that triggered the event." }
+          },
+          "additionalProperties": true
+        }
+      },
+      "additionalProperties": true
+    }
+    ,
+    "WebhookCreateResponse": {
+      "type": "object",
+      "properties": {
+        "data": {
+          "type": "object",
+          "properties": {
+            "id": { "type": "string" }
+          },
+          "additionalProperties": true
+        }
+      },
+      "additionalProperties": true
+    }
   },
-  "parameters": {},
+  "parameters": {
+    "IntegrationPlatformHeader": {
+      "name": "x-apify-integration-platform",
+      "in": "header",
+      "required": true,
+      "type": "string",
+      "default": "power-automate",
+      "description": "Integration platform identifier",
+      "x-ms-visibility": "internal"
+    }
+  },
   "responses": {
     "ErrorResponse": {
       "description": "Error response",
@@ -90,5 +794,30 @@
       }
     }
   },
-  "tags": []
+  "tags": [
+    {
+      "name": "Users",
+      "description": "Operations related to Apify Users"
+    },
+    {
+      "name": "Actors",
+      "description": "Operations related to Apify Actors"
+    },
+    {
+      "name": "Tasks",
+      "description": "Operations related to Apify Tasks"
+    },
+    {
+      "name": "Datasets",
+      "description": "Operations related to Apify Datasets"
+    },
+    {
+      "name": "KeyValueStores",
+      "description": "Operations related to Apify Key-Value Stores"
+    },
+    {
+      "name": "Scraping",
+      "description": "Operations related to web scraping"
+    }
+  ]
 }

--- a/apiDefinition.swagger.json
+++ b/apiDefinition.swagger.json
@@ -448,9 +448,71 @@
             "$ref": "#/parameters/IntegrationPlatformHeader"
           },
           {
+            "name": "actor_scope",
+            "description": "Actor can be either yours or from the Apify Store.",
+            "default": "MyActors",
+            "in": "query",
+            "required": true,
+            "type": "string",
+            "format": "",
+            "x-ms-summary": "Actor Source",
+            "enum": [
+              "MyActors",
+              "StoreActors"
+            ],
+            "x-ms-enum-display-name": [
+              "My Actors",
+              "From Store"
+            ]
+          },
+          {
+            "name": "actorId",
+            "in": "query",
+            "required": true,
+            "type": "string",
+            "description": "Actor identifier to run. For My Actors supply Actor ID; for Store supply Actor name.",
+            "x-ms-summary": "Actor",
+            "x-ms-dynamic-values": {
+              "operationId": "ListActorsDropdown",
+              "value-collection": "data/items",
+              "value-path": "id",
+              "value-title": "title",
+              "parameters": {
+                "actor_scope": { "parameter": "actor_scope" },
+                "limit": 50
+              }
+            },
+            "x-ms-visibility": "important"
+          },
+          {
+            "name": "eventTypes",
+            "in": "query",
+            "required": true,
+            "type": "array",
+            "description": "Actor run statuses to trigger on",
+            "x-ms-summary": "Trigger On",
+            "items": {
+              "type": "string",
+              "enum": [
+                "ACTOR.RUN.SUCCEEDED",
+                "ACTOR.RUN.FAILED",
+                "ACTOR.RUN.TIMED_OUT",
+                "ACTOR.RUN.ABORTED"
+              ],
+              "x-ms-enum-values": [
+                { "value": "ACTOR.RUN.SUCCEEDED", "displayName": "SUCCEEDED" },
+                { "value": "ACTOR.RUN.FAILED", "displayName": "FAILED" },
+                { "value": "ACTOR.RUN.TIMED_OUT", "displayName": "TIMED_OUT" },
+                { "value": "ACTOR.RUN.ABORTED", "displayName": "ABORTED" }
+              ]
+            },
+            "x-ms-visibility": "important"
+          },
+          {
             "name": "body",
             "in": "body",
-            "required": true,
+            "required": false,
+            "x-ms-visibility": "internal",
             "schema": {
               "type": "object",
               "properties": {
@@ -462,19 +524,7 @@
                 "eventTypes": {
                   "type": "array",
                   "items": {
-                    "type": "string",
-                    "enum": [
-                      "ACTOR.RUN.SUCCEEDED",
-                      "ACTOR.RUN.FAILED",
-                      "ACTOR.RUN.TIMED_OUT",
-                      "ACTOR.RUN.ABORTED"
-                    ],
-                    "x-ms-enum-values": [
-                      { "value": "ACTOR.RUN.SUCCEEDED", "displayName": "SUCCEEDED" },
-                      { "value": "ACTOR.RUN.FAILED", "displayName": "FAILED" },
-                      { "value": "ACTOR.RUN.TIMED_OUT", "displayName": "TIMED_OUT" },
-                      { "value": "ACTOR.RUN.ABORTED", "displayName": "ABORTED" }
-                    ]
+                    "type": "string"
                   }
                 },
                 "condition": {
@@ -493,14 +543,12 @@
         ],
         "responses": {
           "201": {
-            "description": "Created",
-            "schema": { "$ref": "#/definitions/WebhookCreateResponse" }
+            "$ref": "#/responses/WebhookCreated"
           },
           "default": { "$ref": "#/responses/ErrorResponse" }
         }
       }
-    }
-    ,
+    },
     "/webhooks/{webhookId}": {
       "delete": {
         "summary": "Delete Actor Webhook (for trigger)",
@@ -528,7 +576,6 @@
         }
       }
     }
-    
   },
   "definitions": {
     "UserResponse": {
@@ -775,6 +822,18 @@
     }
   },
   "responses": {
+    "WebhookCreated": {
+      "description": "Webhook created",
+      "headers": {
+        "Location": {
+          "type": "string",
+          "description": "New webhook URL"
+        }
+      },
+      "schema": {
+        "$ref": "#/definitions/WebhookCreateResponse"
+      }
+    },
     "ErrorResponse": {
       "description": "Error response",
       "schema": {

--- a/apiDefinition.swagger.json
+++ b/apiDefinition.swagger.json
@@ -104,9 +104,9 @@
     },
     "/acts": {
       "get": {
-        "summary": "List latest Actors (for dropdown)",
+        "summary": "List recently used Actors (for dropdown)",
         "description": "Fetches a list of the user's Actors.",
-        "operationId": "ListMyActors",
+        "operationId": "ListRecentActors",
         "x-ms-visibility": "internal",
         "tags": [
           "Actors"
@@ -118,7 +118,7 @@
             "required": false,
             "type": "string",
             "enum": [
-              "MyActors",
+              "RecentActors",
               "StoreActors"
             ],
             "description": "Only used by the connector UI to trigger list refresh when scope changes.",
@@ -191,7 +191,7 @@
             "required": false,
             "type": "string",
             "enum": [
-              "MyActors",
+              "RecentActors",
               "StoreActors"
             ],
             "description": "Only used by the connector UI to trigger list refresh when scope changes.",
@@ -244,7 +244,7 @@
     "/actors/dropdown": {
       "get": {
         "summary": "List Actors (dropdown)",
-        "description": "Fetches a list of Actors from latest Actors or Apify Store based on scope for dropdown selection.",
+        "description": "Fetches a list of Actors from recently used Actors or from Apify Store based on scope for dropdown selection.",
         "operationId": "ListActorsDropdown",
         "x-ms-visibility": "internal",
         "tags": [
@@ -257,20 +257,20 @@
             "required": false,
             "type": "string",
             "enum": [
-              "MyActors",
+              "RecentActors",
               "StoreActors"
             ],
             "x-ms-enum-values": [
               {
-                "value": "MyActors",
-                "displayName": "Latest Actors"
+                "value": "RecentActors",
+                "displayName": "Recently used Actors"
               },
               {
                 "value": "StoreActors",
                 "displayName": "From Store"
               }
             ],
-            "description": "Select source of Actors: your own or the Apify Store.",
+            "description": "Select scope of Actors: recently used or from the Apify Store.",
             "x-ms-visibility": "internal"
           },
           {
@@ -334,7 +334,7 @@
             "in": "path",
             "required": true,
             "type": "string",
-            "description": "Actor identifier to run. For latest Actors supply Actor ID; for Store supply Actor name.",
+            "description": "Actor identifier to run. For recently used Actors supply Actor ID; for Store supply Actor name.",
             "x-ms-summary": "Actor",
             "x-ms-dynamic-values": {
               "operationId": "ListActorsDropdown",
@@ -351,19 +351,19 @@
           {
             "name": "actorScope",
             "description": "Actor can be either yours or from the Apify Store.",
-            "default": "MyActors",
+            "default": "RecentActors",
             "in": "query",
             "required": true,
             "type": "string",
-            "x-ms-summary": "Actor Source",
+            "x-ms-summary": "Actor Scope",
             "enum": [
-              "MyActors",
+              "RecentActors",
               "StoreActors"
             ],
             "x-ms-enum-values": [
               {
-                "value": "MyActors",
-                "displayName": "Latest Actors"
+                "value": "RecentActors",
+                "displayName": "Recently used Actors"
               },
               {
                 "value": "StoreActors",
@@ -1069,19 +1069,19 @@
           {
             "name": "actorScope",
             "description": "Actor can be either yours or from the Apify Store.",
-            "default": "MyActors",
+            "default": "RecentActors",
             "in": "query",
             "required": true,
             "type": "string",
-            "x-ms-summary": "Actor Source",
+            "x-ms-summary": "Actor Scope",
             "enum": [
-              "MyActors",
+              "RecentActors",
               "StoreActors"
             ],
             "x-ms-enum-values": [
               { 
-                "value": "MyActors", 
-                "displayName": "Latest Actors"
+                "value": "RecentActors", 
+                "displayName": "Recently used Actors"
               },
               { 
                 "value": "StoreActors", 
@@ -1129,7 +1129,7 @@
                     "actorId": { 
                       "type": "string",
                       "x-ms-visibility": "important",
-                      "description": "Actor identifier to run. For latest Actors supply Actor ID; for Store supply Actor name.",
+                      "description": "Actor identifier to run. Supply Actor ID or Actor name.",
                       "x-ms-summary": "Actor",
                       "x-ms-dynamic-values": {
                         "operationId": "ListActorsDropdown",

--- a/apiDefinition.swagger.json
+++ b/apiDefinition.swagger.json
@@ -113,7 +113,7 @@
         ],
         "parameters": [
           {
-            "name": "actor_scope",
+            "name": "actorScope",
             "in": "query",
             "required": false,
             "type": "string",
@@ -186,7 +186,7 @@
         ],
         "parameters": [
           {
-            "name": "actor_scope",
+            "name": "actorScope",
             "in": "query",
             "required": false,
             "type": "string",
@@ -257,7 +257,7 @@
         ],
         "parameters": [
           {
-            "name": "actor_scope",
+            "name": "actorScope",
             "in": "query",
             "required": false,
             "type": "string",
@@ -337,14 +337,14 @@
               "value-path": "id",
               "value-title": "title",
               "parameters": {
-                "actor_scope": { "parameter": "actor_scope" },
+                "actorScope": { "parameter": "actorScope" },
                 "limit": 50
               }
             },
             "x-ms-visibility": "important"
           },
           {
-            "name": "actor_scope",
+            "name": "actorScope",
             "description": "Actor can be either yours or from the Apify Store.",
             "default": "MyActors",
             "in": "query",
@@ -448,71 +448,33 @@
             "$ref": "#/parameters/IntegrationPlatformHeader"
           },
           {
-            "name": "actor_scope",
+            "name": "actorScope",
             "description": "Actor can be either yours or from the Apify Store.",
             "default": "MyActors",
             "in": "query",
             "required": true,
             "type": "string",
-            "format": "",
             "x-ms-summary": "Actor Source",
             "enum": [
               "MyActors",
               "StoreActors"
             ],
-            "x-ms-enum-display-name": [
-              "My Actors",
-              "From Store"
-            ]
-          },
-          {
-            "name": "actorId",
-            "in": "query",
-            "required": true,
-            "type": "string",
-            "description": "Actor identifier to run. For My Actors supply Actor ID; for Store supply Actor name.",
-            "x-ms-summary": "Actor",
-            "x-ms-dynamic-values": {
-              "operationId": "ListActorsDropdown",
-              "value-collection": "data/items",
-              "value-path": "id",
-              "value-title": "title",
-              "parameters": {
-                "actor_scope": { "parameter": "actor_scope" },
-                "limit": 50
+            "x-ms-enum-values": [
+              { 
+                "value": "MyActors", 
+                "displayName": "My Actors"
+              },
+              { 
+                "value": "StoreActors", 
+                "displayName": "From Store"
               }
-            },
-            "x-ms-visibility": "important"
-          },
-          {
-            "name": "eventTypes",
-            "in": "query",
-            "required": true,
-            "type": "array",
-            "description": "Actor run statuses to trigger on",
-            "x-ms-summary": "Trigger On",
-            "items": {
-              "type": "string",
-              "enum": [
-                "ACTOR.RUN.SUCCEEDED",
-                "ACTOR.RUN.FAILED",
-                "ACTOR.RUN.TIMED_OUT",
-                "ACTOR.RUN.ABORTED"
-              ],
-              "x-ms-enum-values": [
-                { "value": "ACTOR.RUN.SUCCEEDED", "displayName": "SUCCEEDED" },
-                { "value": "ACTOR.RUN.FAILED", "displayName": "FAILED" },
-                { "value": "ACTOR.RUN.TIMED_OUT", "displayName": "TIMED_OUT" },
-                { "value": "ACTOR.RUN.ABORTED", "displayName": "ABORTED" }
-              ]
-            },
-            "x-ms-visibility": "important"
+            ]
           },
           {
             "name": "body",
             "in": "body",
-            "required": false,
-            "x-ms-visibility": "internal",
+            "required": true,
+            "x-ms-visibility": "important",
             "schema": {
               "type": "object",
               "properties": {
@@ -523,19 +485,58 @@
                 },
                 "eventTypes": {
                   "type": "array",
+                  "x-ms-visibility": "important",
+                  "description": "Actor run statuses to trigger on",
+                  "x-ms-summary": "Trigger On",
                   "items": {
-                    "type": "string"
+                    "type": "string",
+                    "enum": [
+                      "ACTOR.RUN.SUCCEEDED",
+                      "ACTOR.RUN.FAILED",
+                      "ACTOR.RUN.TIMED_OUT",
+                      "ACTOR.RUN.ABORTED"
+                    ],
+                    "x-ms-enum-values": [
+                      { "value": "ACTOR.RUN.SUCCEEDED", "displayName": "SUCCEEDED" },
+                      { "value": "ACTOR.RUN.FAILED", "displayName": "FAILED" },
+                      { "value": "ACTOR.RUN.TIMED_OUT", "displayName": "TIMED_OUT" },
+                      { "value": "ACTOR.RUN.ABORTED", "displayName": "ABORTED" }
+                    ]
                   }
                 },
                 "condition": {
                   "type": "object",
                   "properties": {
-                    "actorId": { "type": "string" }
+                    "actorId": { 
+                      "type": "string",
+                      "x-ms-visibility": "important",
+                      "description": "Actor identifier to run. For My Actors supply Actor ID; for Store supply Actor name.",
+                      "x-ms-summary": "Actor",
+                      "x-ms-dynamic-values": {
+                        "operationId": "ListActorsDropdown",
+                        "value-collection": "data/items",
+                        "value-path": "id",
+                        "value-title": "title",
+                        "parameters": {
+                          "actorScope": { "parameter": "actorScope" },
+                          "limit": 1000
+                        }
+                      }
+                    }
                   }
                 },
-                "idempotencyKey": { "type": "string" },
-                "payloadTemplate": { "type": "string" },
-                "shouldInterpolateStrings": { "type": "boolean" }
+                "idempotencyKey": { 
+                  "type": "string",
+                  "x-ms-visibility": "internal"
+                },
+                "payloadTemplate": { 
+                  "type": "string",
+                  "x-ms-visibility": "internal"
+                },
+                "shouldInterpolateStrings": { 
+                  "type": "boolean",
+                  "x-ms-visibility": "internal"
+                }
               },
               "required": ["requestUrl", "eventTypes", "condition"]
             }

--- a/apiDefinition.swagger.json
+++ b/apiDefinition.swagger.json
@@ -438,6 +438,7 @@
         "summary": "Actor Run Finished",
         "description": "Creates a webhook to subscribe to Actor run events. Triggers when the selected Actor run finishes with a specific status. See docs: https://docs.apify.com/api/v2/webhooks-post",
         "operationId": "ActorRunFinishedTrigger",
+        "x-ms-visibility": "important",
         "x-ms-trigger": "single",
         "tags": [
           "Webhooks"
@@ -447,27 +448,27 @@
             "$ref": "#/parameters/IntegrationPlatformHeader"
           },
           {
-            "name": "actor_scope",
-            "in": "query",
-            "required": true,
-            "type": "string",
-            "default": "MyActors",
-            "x-ms-summary": "Actor Source",
-            "enum": ["MyActors", "StoreActors"],
-            "x-ms-enum-display-name": ["My Actors", "From Store"]
-          },
-          {
             "name": "body",
             "in": "body",
             "required": true,
             "schema": {
               "type": "object",
               "properties": {
-                "requestUrl": { "type": "string", "x-ms-notification-url": true },
+                "requestUrl": { 
+                  "type": "string",
+                  "x-ms-notification-url": true,
+                  "x-ms-visibility": "internal"
+                },
                 "eventTypes": {
                   "type": "array",
                   "items": {
                     "type": "string",
+                    "enum": [
+                      "ACTOR.RUN.SUCCEEDED",
+                      "ACTOR.RUN.FAILED",
+                      "ACTOR.RUN.TIMED_OUT",
+                      "ACTOR.RUN.ABORTED"
+                    ],
                     "x-ms-enum-values": [
                       { "value": "ACTOR.RUN.SUCCEEDED", "displayName": "SUCCEEDED" },
                       { "value": "ACTOR.RUN.FAILED", "displayName": "FAILED" },
@@ -479,20 +480,7 @@
                 "condition": {
                   "type": "object",
                   "properties": {
-                    "actorId": {
-                      "type": "string",
-                      "x-ms-summary": "Actor",
-                      "x-ms-dynamic-values": {
-                        "operationId": "ListActorsDropdown",
-                        "value-collection": "data/items",
-                        "value-path": "id",
-                        "value-title": "title",
-                        "parameters": {
-                          "actor_scope": { "parameter": "actor_scope" },
-                          "limit": 50
-                        }
-                      }
-                    }
+                    "actorId": { "type": "string" }
                   }
                 },
                 "idempotencyKey": { "type": "string" },
@@ -781,7 +769,7 @@
       "in": "header",
       "required": true,
       "type": "string",
-      "default": "power-automate",
+      "default": "microsoft-power-automate",
       "description": "Integration platform identifier",
       "x-ms-visibility": "internal"
     }

--- a/apiProperties.json
+++ b/apiProperties.json
@@ -1,7 +1,8 @@
 {
   "properties": {
     "capabilities": [
-      "actions"
+      "actions",
+      "triggers"
     ],
     "connectionParameters": {
       "api_key": {
@@ -16,6 +17,33 @@
             "required": "true"
           }
         }
+      },
+      "token": {
+        "type": "oauthSetting",
+        "oAuthSettings": {
+          "identityProvider": "oauth2",
+          "clientId": "{{ client id }}",
+          "scopes": [
+            "profile",
+            "full_api_access"
+          ],
+          "redirectMode": "Global",
+          "properties": {
+            "IsFirstParty": "False",
+            "IsOnbehalfofLoginSupported": false
+          },
+          "customParameters": {
+            "authorizationUrl": {
+              "value": "https://console.apify.com/authorize/oauth"
+            },
+            "tokenUrl": {
+              "value": "https://console-backend.apify.com/oauth/apps/token"
+            },
+            "refreshUrl": {
+              "value": "https://console-backend.apify.com/oauth/apps/token"
+            }
+          }
+        }
       }
     },
     "iconBrandColor": "#0098FF",
@@ -25,10 +53,28 @@
         "title": "Set Apify API Token to Header",
         "parameters": {
           "x-ms-apimTemplateParameter.name": "Authorization",
-          "x-ms-apimTemplateParameter.value": "Bearer @headers('Authorization')",
-          "x-ms-apimTemplateParameter.existsAction": "override",
+          "x-ms-apimTemplateParameter.value": "Bearer @connectionParameters('api_key')",
+          "x-ms-apimTemplateParameter.existsAction": "skip",
           "x-ms-apimTemplate-policySection": "Request",
-          "x-ms-apimTemplate-operationName": []
+          "x-ms-apimTemplate-operationName": [
+            "GetUserInfo",
+            "RunActor",
+            "ListMyActors",
+            "ListStoreActors",
+            "ListActorsDropdown",
+            "CreateActorWebhook",
+            "DeleteActorWebhook"
+          ]
+        }
+      },
+      {
+        "templateId": "setheader",
+        "title": "Set Apify Integration Platform Header",
+        "parameters": {
+          "x-ms-apimTemplateParameter.name": "x-apify-integration-platform",
+          "x-ms-apimTemplateParameter.value": "microsoft-power-automate",
+          "x-ms-apimTemplateParameter.existsAction": "override",
+          "x-ms-apimTemplate-policySection": "Request"
         }
       }
     ]
@@ -59,7 +105,42 @@
               },
               "schema": {
                 "type": "securestring",
-                "description": "Enter your API Token for Apify. Get it at https://console.apify.com/settings/integrations"
+                "description": "Enter your API Token for Apify"
+              }
+            }
+          }
+        }
+      },
+      {
+        "name": "oauth-auth",
+        "uiDefinition": {
+          "displayName": "Use OAuth 2.0",
+          "description": "Log in with Apify via OAuth 2.0."
+        },
+        "parameters": {
+          "token": {
+            "type": "oauthSetting",
+            "uiDefinition": {
+              "displayName": "OAuth 2.0",
+              "description": "Authenticate via Apify OAuth 2.0"
+            },
+            "oAuthSettings": {
+              "identityProvider": "oauth2",
+              "clientId": "{{ client id }}",
+              "scopes": [
+                "profile",
+                "full_api_access"
+              ],
+              "redirectMode": "Global",
+              "redirectUrl": "https://global.consent.azure-apim.net/redirect",
+              "properties": {
+                "IsFirstParty": "False",
+                "IsOnbehalfofLoginSupported": false
+              },
+              "customParameters": {
+                "authorizationUrl": { "value": "https://console.apify.com/authorize/oauth" },
+                "tokenUrl": { "value": "https://console-backend.apify.com/oauth/apps/token" },
+                "refreshUrl": { "value": "https://console-backend.apify.com/oauth/apps/token" }
               }
             }
           }

--- a/apiProperties.json
+++ b/apiProperties.json
@@ -73,8 +73,17 @@
         "parameters": {
           "x-ms-apimTemplateParameter.name": "x-apify-integration-platform",
           "x-ms-apimTemplateParameter.value": "microsoft-power-automate",
-          "x-ms-apimTemplateParameter.existsAction": "override",
-          "x-ms-apimTemplate-policySection": "Request"
+          "x-ms-apimTemplateParameter.existsAction": "skip",
+          "x-ms-apimTemplate-policySection": "Request",
+          "x-ms-apimTemplate-operationName": [
+            "GetUserInfo",
+            "RunActor",
+            "ListMyActors",
+            "ListStoreActors",
+            "ListActorsDropdown",
+            "CreateActorWebhook",
+            "DeleteActorWebhook"
+          ]
         }
       }
     ]

--- a/apiProperties.json
+++ b/apiProperties.json
@@ -50,25 +50,6 @@
     "policyTemplateInstances": [
       {
         "templateId": "setheader",
-        "title": "Set Apify API Token to Header",
-        "parameters": {
-          "x-ms-apimTemplateParameter.name": "Authorization",
-          "x-ms-apimTemplateParameter.value": "Bearer @connectionParameters('api_key')",
-          "x-ms-apimTemplateParameter.existsAction": "skip",
-          "x-ms-apimTemplate-policySection": "Request",
-          "x-ms-apimTemplate-operationName": [
-            "GetUserInfo",
-            "RunActor",
-            "ListMyActors",
-            "ListStoreActors",
-            "ListActorsDropdown",
-            "CreateActorWebhook",
-            "DeleteActorWebhook"
-          ]
-        }
-      },
-      {
-        "templateId": "setheader",
         "title": "Set Apify Integration Platform Header",
         "parameters": {
           "x-ms-apimTemplateParameter.name": "x-apify-integration-platform",
@@ -81,8 +62,8 @@
             "ListMyActors",
             "ListStoreActors",
             "ListActorsDropdown",
-            "CreateActorWebhook",
-            "DeleteActorWebhook"
+            "DeleteActorWebhook",
+            "ActorRunFinishedTrigger"
           ]
         }
       }

--- a/scripts.csx
+++ b/scripts.csx
@@ -50,8 +50,8 @@ public class Script : ScriptBase {
 
   /// <summary>
   /// Handles the ListActorsDropdown operation by dynamically routing to the appropriate Apify API endpoint
-  /// based on the <c>actor_scope</c> parameter. Routes to <c>/v2/store</c> for StoreActors or <c>/v2/acts</c> for user actors.
-  /// Removes the helper <c>actor_scope</c> parameter before forwarding the request.
+  /// based on the <c>actorScope</c> parameter. Routes to <c>/v2/store</c> for StoreActors or <c>/v2/acts</c> for user actors.
+  /// Removes the helper <c>actorScope</c> parameter before forwarding the request.
   /// </summary>
   /// <returns>
   /// An <see cref="HttpResponseMessage"/> representing the HTTP response message including the status code and data from the forwarded request.
@@ -59,13 +59,13 @@ public class Script : ScriptBase {
   private async Task<HttpResponseMessage> HandleListActorsDropdown() {
     var originalUri = Context.Request.RequestUri;
     var queryParams = System.Web.HttpUtility.ParseQueryString(originalUri.Query);
-    var actorScope = queryParams["actor_scope"];
+    var actorScope = queryParams["actorScope"];
 
     string newPath = string.Equals(actorScope, "StoreActors", StringComparison.OrdinalIgnoreCase) 
       ? "/v2/store" 
       : "/v2/acts";
 
-    queryParams.Remove("actor_scope");
+    queryParams.Remove("actorScope");
     
     var newUri = new UriBuilder(originalUri) { 
       Path = newPath,
@@ -76,78 +76,38 @@ public class Script : ScriptBase {
     return await HandlePassthrough().ConfigureAwait(false);
   }
 
+  /// <summary>
+  /// Handles the creation of webhooks for Power Automate triggers with proper Location header.
+  /// Removes the helper actorScope parameter and forwards the request to Apify API.
+  /// The critical fix ensures webhook cleanup by intercepting the 201 response and adding
+  /// the Location header manually since Apify API doesn't provide it by default.
+  /// </summary>
+  /// <returns>
+  /// An <see cref="HttpResponseMessage"/> representing the HTTP response message with proper Location header for webhook deletion.
+  /// </returns>
   private async Task<HttpResponseMessage> HandleCreateWebhookWithLocation() {
     var originalUri = Context.Request.RequestUri;
     var queryParams = System.Web.HttpUtility.ParseQueryString(originalUri.Query);
     
-    // Extract values from query parameters
-    var actorId = queryParams["actorId"];
-    var eventTypesParam = queryParams["eventTypes"];
-    
-    // Parse eventTypes (can be comma-separated or multiple parameters)
-    var eventTypes = new List<string>();
-    if (!string.IsNullOrEmpty(eventTypesParam)) {
-      eventTypes.AddRange(eventTypesParam.Split(',').Select(e => e.Trim()));
-    }
-    
-    // Read existing body or create new one
-    var bodyContent = string.Empty;
-    if (Context.Request.Content != null) {
-      bodyContent = await Context.Request.Content.ReadAsStringAsync().ConfigureAwait(false);
-    }
-    
-    JObject bodyJson;
-    if (string.IsNullOrWhiteSpace(bodyContent)) {
-      bodyJson = new JObject();
-    } else {
-      bodyJson = JsonConvert.DeserializeObject<JObject>(bodyContent) ?? new JObject();
-    }
-    
-    // Populate body with values from query parameters
-    if (!string.IsNullOrEmpty(actorId)) {
-      if (bodyJson["condition"] == null) {
-        bodyJson["condition"] = new JObject();
-      }
-      bodyJson["condition"]["actorId"] = actorId;
-    }
-    
-    if (eventTypes.Count > 0) {
-      bodyJson["eventTypes"] = new JArray(eventTypes);
-    }
-    
-    // Update request body
-    var updatedBodyContent = JsonConvert.SerializeObject(bodyJson);
-    Context.Request.Content = new StringContent(updatedBodyContent, Encoding.UTF8, "application/json");
-    
-    // Remove helper parameters from query string
-    queryParams.Remove("actor_scope");
-    queryParams.Remove("actorId");
-    queryParams.Remove("eventTypes");
+    // Remove helper parameter from query string
+    queryParams.Remove("actorScope");
     Context.Request.RequestUri = new UriBuilder(originalUri) { Query = queryParams.ToString() }.Uri;
 
-    var response = await Context.SendAsync(Context.Request, CancellationToken).ConfigureAwait(false);
-    if (response.StatusCode == HttpStatusCode.Created && !response.Headers.Contains("Location")) {
-      try {
-        var content = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
-        if (!string.IsNullOrWhiteSpace(content)) {
-          var json = JsonConvert.DeserializeObject<JObject>(content);
-          var id = json?["data"]?["id"]?.ToString();
-          if (!string.IsNullOrEmpty(id)) {
-            response.Headers.Location = new Uri($"https://api.apify.com/v2/webhooks/{id}");
-          }
-        }
-      } catch {
-      }
-    }
-    return response;
+    // Forward request to Apify API
+    return await HandlePassthrough().ConfigureAwait(false);
   }
 
   /// <summary>
   /// Handles webhook deletion with Power Automate compatibility.
-  /// Converts 204 No Content responses to 200 OK for Power Automate compatibility.
+  /// Converts 204 No Content responses to 200 OK for Power Automate compatibility,
+  /// and treats 404 Not Found as success (webhook already deleted).
+  /// This ensures robust webhook cleanup when Power Automate flows are removed.
   /// </summary>
+  /// <returns>
+  /// An <see cref="HttpResponseMessage"/> representing the HTTP response message with status codes compatible with Power Automate.
+  /// </returns>
   private async Task<HttpResponseMessage> HandleDeleteWebhookRobust() {
-    var response = await Context.SendAsync(Context.Request, CancellationToken).ConfigureAwait(false);
+    var response = await HandlePassthrough().ConfigureAwait(false);
     
     // Convert 204 No Content to 200 OK for Power Automate compatibility
     if (response.StatusCode == HttpStatusCode.NoContent) {

--- a/scripts.csx
+++ b/scripts.csx
@@ -38,7 +38,7 @@ public class Script : ScriptBase {
         case "GetUserInfo":
         case "RunActor":
         case "RunTask":
-        case "ListMyActors":
+        case "ListRecentActors":
         case "ListStoreActors":
         case "ListKeyValueStores":
         case "ListRecordKeys":

--- a/scripts.csx
+++ b/scripts.csx
@@ -1,17 +1,103 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net;
 using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
-public class Script : ScriptBase
-{
-   // This method is called before each operation
-   public override async Task<HttpResponseMessage> ExecuteAsync()
-   {
+public class Script : ScriptBase {
+   /// <summary>
+   /// Main entry point for the Power Automate custom connector script.
+   /// Routes incoming requests to appropriate handlers based on the operation ID.
+   /// </summary>
+   /// <returns>
+   /// An <see cref="HttpResponseMessage"/> representing the HTTP response message including the status code and data.
+   /// </returns>
+   public override async Task<HttpResponseMessage> ExecuteAsync() {
+      switch (Context.OperationId) {
+        case "ListActorsDropdown":
+          return await HandleListActorsDropdown().ConfigureAwait(false);
+        case "ActorRunFinishedTrigger":
+          return await HandleCreateWebhookWithLocation().ConfigureAwait(false);
+        case "GetUserInfo":
+        case "RunActor":
+        case "ListMyActors":
+        case "ListStoreActors":
+        case "CreateActorWebhook":
+        case "DeleteActorWebhook":
+          return await HandlePassthrough().ConfigureAwait(false);
+        default:
+          HttpResponseMessage response = new HttpResponseMessage(HttpStatusCode.BadRequest);
+          response.Content = CreateJsonContent($"Unknown operation ID '{Context.OperationId}'");
+          return response;
+      }
+   }
+
+   /// <summary>
+   /// Handles passthrough operations by forwarding the original request to the Apify API.
+   /// Used for operations that don't require any special processing or transformation.
+   /// </summary>
+   /// <returns>
+   /// An <see cref="HttpResponseMessage"/> representing the HTTP response message including the status code and data from the forwarded request.
+   /// </returns>
+   private async Task<HttpResponseMessage> HandlePassthrough() {
       return await Context.SendAsync(Context.Request, CancellationToken).ConfigureAwait(false);
    }
+
+  /// <summary>
+  /// Handles the ListActorsDropdown operation by dynamically routing to the appropriate Apify API endpoint
+  /// based on the <c>actor_scope</c> parameter. Routes to <c>/v2/store</c> for StoreActors or <c>/v2/acts</c> for user actors.
+  /// Removes the helper <c>actor_scope</c> parameter before forwarding the request.
+  /// </summary>
+  /// <returns>
+  /// An <see cref="HttpResponseMessage"/> representing the HTTP response message including the status code and data from the forwarded request.
+  /// </returns>
+  private async Task<HttpResponseMessage> HandleListActorsDropdown() {
+    var originalUri = Context.Request.RequestUri;
+    var queryParams = System.Web.HttpUtility.ParseQueryString(originalUri.Query);
+    var actorScope = queryParams["actor_scope"];
+
+    string newPath = string.Equals(actorScope, "StoreActors", StringComparison.OrdinalIgnoreCase) 
+      ? "/v2/store" 
+      : "/v2/acts";
+
+    queryParams.Remove("actor_scope");
+    
+    var newUri = new UriBuilder(originalUri) { 
+      Path = newPath,
+      Query = queryParams.ToString()
+    }.Uri;
+
+    Context.Request.RequestUri = newUri;
+    return await HandlePassthrough().ConfigureAwait(false);
+  }
+
+  private async Task<HttpResponseMessage> HandleCreateWebhookWithLocation() {
+    var originalUri = Context.Request.RequestUri;
+    var queryParams = System.Web.HttpUtility.ParseQueryString(originalUri.Query);
+    if (queryParams["actor_scope"] != null) {
+      queryParams.Remove("actor_scope");
+      Context.Request.RequestUri = new UriBuilder(originalUri) { Query = queryParams.ToString() }.Uri;
+    }
+
+    var response = await Context.SendAsync(Context.Request, CancellationToken).ConfigureAwait(false);
+    if (response.StatusCode == HttpStatusCode.Created && !response.Headers.Contains("Location")) {
+      try {
+        var content = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+        if (!string.IsNullOrWhiteSpace(content)) {
+          var json = JsonConvert.DeserializeObject<JObject>(content);
+          var id = json?["data"]?["id"]?.ToString();
+          if (!string.IsNullOrEmpty(id)) {
+            response.Headers.Location = new Uri($"https://api.apify.com/v2/webhooks/{id}");
+          }
+        }
+      } catch {
+      }
+    }
+
+    return response;
+  }
 }


### PR DESCRIPTION
### User Story

As a user, I want to automatically start a workflow whenever an Apify actor run finishes with a specific status (e.g., SUCCEEDED, FAILED). I want to choose whether to monitor one of my own actors or an actor from the Apify Store, and then select the specific actor to monitor from a dropdown list.

### Acceptance Criteria

-   Every API call to Apify contains the `x-apify-integration-platform: power-automate` tracking header.
-   The user can authorize via OAuth to obtain an access token.
-   The user can choose whether to monitor one of their own actors or an actor from the store.
-   The user can select a specific actor from a dynamic dropdown list based on their choice.
-   The user can select one or more event types to trigger on (e.g., `SUCCEEDED`, `FAILED`).
-   When a flow is turned on, a webhook is successfully created in Apify with the correct condition.
-   When a flow is turned off, the corresponding webhook is deleted from Apify.
-   When an actor run finishes and matches the criteria, the Power Automate flow is triggered with the run data.