### PR TITLE
fix: remove : remove client id from code

### DIFF
--- a/apiProperties.json
+++ b/apiProperties.json
@@ -18,7 +18,7 @@
         },
         "oAuthSettings": {
           "identityProvider": "oauth2",
-          "clientId": "tGv12tNFeY7seZbyq",
+          "clientId": "{{ client id }}",
           "clientSecret": "{{ client secret }}",
           "scopes": [
             "profile",


### PR DESCRIPTION
In the submission process, it is stated that MS will set both the client ID and client secret; therefore, it's better to have them as such for both values.