### PR TITLE
Validate query parameters

### DIFF
--- a/apiProperties.json
+++ b/apiProperties.json
@@ -1,9 +1,5 @@
 {
   "properties": {
-    "capabilities": [
-      "actions",
-      "triggers"
-    ],
     "connectionParameters": {
       "token": {
         "type": "oauthSetting",

--- a/scripts.csx
+++ b/scripts.csx
@@ -584,23 +584,6 @@ public class Script : ScriptBase {
   }
 
   /// <summary>
-  /// Validates that a parameter value is a positive integer (greater than 0).
-  /// </summary>
-  /// <param name="paramName">The name of the parameter being validated.</param>
-  /// <param name="paramValue">The value to validate.</param>
-  /// <returns>ValidationResult indicating success or failure with error message.</returns>
-  private ValidationResult ValidatePositiveInteger(string paramName, string paramValue) {
-    var result = new ValidationResult();
-    
-    if (int.TryParse(paramValue, out var value) && value > 0) {
-      return result;
-    }
-    
-    result.AddError($"Parameter '{paramName}' must be a positive integer");
-    return result;
-  }
-
-  /// <summary>
   /// Validates that a parameter value is a non-negative integer (greater than or equal to 0).
   /// </summary>
   /// <param name="paramName">The name of the parameter being validated.</param>
@@ -655,17 +638,17 @@ public class Script : ScriptBase {
     return new Dictionary<string, Dictionary<string, ParameterValidator>> {
       [OP_RUN_ACTOR_ID] = new Dictionary<string, ParameterValidator> {
         ["waitForFinish"] = ValidateWaitForFinish,
-        ["timeout"] = ValidatePositiveInteger
+        ["timeout"] = ValidateNonNegativeInteger
       },
       [OP_RUN_TASK_ID] = new Dictionary<string, ParameterValidator> {
         ["waitForFinish"] = ValidateWaitForFinish,
-        ["timeout"] = ValidatePositiveInteger
+        ["timeout"] = ValidateNonNegativeInteger
       },
       [OP_SCRAPE_SINGLE_URL_ID] = new Dictionary<string, ParameterValidator> {
         ["url"] = ValidateUrl
       },
       [OP_GET_DATASET_ITEMS_ID] = new Dictionary<string, ParameterValidator> {
-        ["limit"] = ValidatePositiveInteger,
+        ["limit"] = ValidateNonNegativeInteger,
         ["offset"] = ValidateNonNegativeInteger
       }
     };

--- a/scripts.csx
+++ b/scripts.csx
@@ -483,7 +483,8 @@ public class Script : ScriptBase {
   /// <summary>
   /// Handles the creation of webhooks for Power Automate triggers.
   /// Location header is provided by Apify API.
-  /// Removes the helper actorScope parameter and forwards the request to Apify API.  /// </summary>
+  /// Removes the helper actorScope parameter and forwards the request to Apify API.  
+  /// </summary>
   /// <returns>
   /// An <see cref="HttpResponseMessage"/> representing the HTTP response message with proper Location header for webhook deletion.
   /// </returns>
@@ -495,7 +496,7 @@ public class Script : ScriptBase {
     queryParams.Remove("actorScope");
     Context.Request.RequestUri = new UriBuilder(originalUri) { Query = queryParams.ToString() }.Uri;
 
-    // Forward request to Apify API (bypass validation in passthrough since we already validated)
+    // Forward request to Apify API
     return await Context.SendAsync(Context.Request, CancellationToken).ConfigureAwait(false);
   }
 
@@ -561,9 +562,9 @@ public class Script : ScriptBase {
   /// <summary>
   /// Validates that a parameter value is a valid URL.
   /// </summary>
-  /// <param name="paramName">The name of the parameter being validated</param>
-  /// <param name="paramValue">The value to validate</param>
-  /// <returns>ValidationResult indicating success or failure with error message</returns>
+  /// <param name="paramName">The name of the parameter being validated.</param>
+  /// <param name="paramValue">The value to validate.</param>
+  /// <returns>ValidationResult indicating success or failure with error message.</returns>
   private ValidationResult ValidateUrl(string paramName, string paramValue) {
     var result = new ValidationResult();
     
@@ -579,9 +580,9 @@ public class Script : ScriptBase {
   /// <summary>
   /// Validates that a parameter value is a positive integer (greater than 0).
   /// </summary>
-  /// <param name="paramName">The name of the parameter being validated</param>
-  /// <param name="paramValue">The value to validate</param>
-  /// <returns>ValidationResult indicating success or failure with error message</returns>
+  /// <param name="paramName">The name of the parameter being validated.</param>
+  /// <param name="paramValue">The value to validate.</param>
+  /// <returns>ValidationResult indicating success or failure with error message.</returns>
   private ValidationResult ValidatePositiveInteger(string paramName, string paramValue) {
     var result = new ValidationResult();
     
@@ -596,9 +597,9 @@ public class Script : ScriptBase {
   /// <summary>
   /// Validates that a parameter value is a non-negative integer (greater than or equal to 0).
   /// </summary>
-  /// <param name="paramName">The name of the parameter being validated</param>
-  /// <param name="paramValue">The value to validate</param>
-  /// <returns>ValidationResult indicating success or failure with error message</returns>
+  /// <param name="paramName">The name of the parameter being validated.</param>
+  /// <param name="paramValue">The value to validate.</param>
+  /// <returns>ValidationResult indicating success or failure with error message.</returns>
   private ValidationResult ValidateNonNegativeInteger(string paramName, string paramValue) {
     var result = new ValidationResult();
     
@@ -613,10 +614,10 @@ public class Script : ScriptBase {
   /// <summary>
   /// Validates that a parameter value is an integer within a specified range.
   /// </summary>
-  /// <param name="paramName">The name of the parameter being validated</param>
-  /// <param name="paramValue">The value to validate</param>
-  /// <param name="min">Minimum allowed value (inclusive)</param>
-  /// <param name="max">Maximum allowed value (inclusive)</param>
+  /// <param name="paramName">The name of the parameter being validated.</param>
+  /// <param name="paramValue">The value to validate.</param>
+  /// <param name="min">Minimum allowed value.</param>
+  /// <param name="max">Maximum allowed value.</param>
   /// <returns>ValidationResult indicating success or failure with error message</returns>
   private ValidationResult ValidateIntegerRange(string paramName, string paramValue, int min, int max) {
     var result = new ValidationResult();
@@ -632,9 +633,9 @@ public class Script : ScriptBase {
   /// <summary>
   /// Validates that a parameter value is a valid wait for finish value (0-60).
   /// </summary>
-  /// <param name="paramName">The name of the parameter being validated</param>
-  /// <param name="paramValue">The value to validate</param>
-  /// <returns>ValidationResult indicating success or failure with error message</returns>
+  /// <param name="paramName">The name of the parameter being validated.</param>
+  /// <param name="paramValue">The value to validate.</param>
+  /// <returns>ValidationResult indicating success or failure with error message.</returns>
   private ValidationResult ValidateWaitForFinish(string paramName, string paramValue) {
     return ValidateIntegerRange(paramName, paramValue, 0, 60);
   }
@@ -643,7 +644,7 @@ public class Script : ScriptBase {
   /// Returns validation rules for each operation that requires query parameter validation.
   /// Maps operation IDs to their parameter validation rules.
   /// </summary>
-  /// <returns>Dictionary mapping operation IDs to parameter validators</returns>
+  /// <returns>Dictionary mapping operation IDs to parameter validators.</returns>
   private Dictionary<string, Dictionary<string, ParameterValidator>> GetValidationRules() {
     return new Dictionary<string, Dictionary<string, ParameterValidator>> {
       ["RunActor"] = new Dictionary<string, ParameterValidator> {
@@ -667,9 +668,9 @@ public class Script : ScriptBase {
   /// <summary>
   /// Validates query parameters for a given operation based on configured validation rules.
   /// </summary>
-  /// <param name="operationId">The operation ID to validate parameters for</param>
-  /// <param name="queryParams">The query parameters collection to validate</param>
-  /// <returns>ValidationResult containing all validation errors, if any</returns>
+  /// <param name="operationId">The operation ID to validate parameters for.</param>
+  /// <param name="queryParams">The query parameters collection to validate.</param>
+  /// <returns>ValidationResult containing all validation errors, if any.</returns>
   private ValidationResult ValidateQueryParameters(string operationId, System.Collections.Specialized.NameValueCollection queryParams) {
     var result = new ValidationResult();
     var rules = GetValidationRules();
@@ -696,8 +697,8 @@ public class Script : ScriptBase {
   /// <summary>
   /// Creates a standardized HTTP 400 Bad Request response for validation errors.
   /// </summary>
-  /// <param name="validation">The validation result containing error details</param>
-  /// <returns>HttpResponseMessage with validation error details</returns>
+  /// <param name="validation">The validation result containing error details.</param>
+  /// <returns>HttpResponseMessage with validation error details.</returns>
   private HttpResponseMessage CreateValidationErrorResponse(ValidationResult validation) {
     var errorResponse = new HttpResponseMessage(HttpStatusCode.BadRequest);
     var errorObject = new JObject {

--- a/scripts.csx
+++ b/scripts.csx
@@ -8,6 +8,12 @@ using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
 public class Script : ScriptBase {
+  /// Constants
+  private const string OP_RUN_ACTOR_ID = "RunActor";
+  private const string OP_RUN_TASK_ID = "RunTask";
+  private const string OP_SCRAPE_SINGLE_URL_ID = "ScrapeSingleUrl";
+  private const string OP_GET_DATASET_ITEMS_ID = "GetDatasetItems";
+
   /// <summary>
   /// Main entry point for the Power Automate custom connector script.
   /// Routes incoming requests to appropriate handlers based on the operation ID.
@@ -23,7 +29,7 @@ public class Script : ScriptBase {
         return await HandleListTasks().ConfigureAwait(false);
       case "GetDatasetSchema":
         return await HandleGetDatasetSchema().ConfigureAwait(false);
-      case "ScrapeSingleUrl":
+      case OP_SCRAPE_SINGLE_URL_ID:
         return await HandleScrapeSingleUrl().ConfigureAwait(false);
       case "GetKeyValueStoreRecordSchema":
         return await HandleGetKeyValueStoreRecordSchema().ConfigureAwait(false);
@@ -35,13 +41,13 @@ public class Script : ScriptBase {
         return await HandleCreateWebhook().ConfigureAwait(false);
       case "DeleteActorWebhook":
         return await HandleDeleteWebhook().ConfigureAwait(false);
-      case "RunActor":
-      case "RunTask":
+      case OP_GET_DATASET_ITEMS_ID:
+      case OP_RUN_ACTOR_ID:
+      case OP_RUN_TASK_ID:
       case "GetUserInfo":
       case "ListDatasets":
       case "ListRecordKeys":
       case "ListStoreActors":
-      case "GetDatasetItems":
       case "ListRecentActors":
       case "ListKeyValueStores":
       case "GetKeyValueStoreRecord":
@@ -89,7 +95,7 @@ public class Script : ScriptBase {
       var queryParams = System.Web.HttpUtility.ParseQueryString(request.RequestUri.Query);
 
       // Validate query parameters
-      var validation = ValidateQueryParameters("ScrapeSingleUrl", queryParams);
+      var validation = ValidateQueryParameters(OP_SCRAPE_SINGLE_URL_ID, queryParams);
       if (!validation.IsValid) {
         return CreateValidationErrorResponse(validation);
       }
@@ -647,18 +653,18 @@ public class Script : ScriptBase {
   /// <returns>Dictionary mapping operation IDs to parameter validators.</returns>
   private Dictionary<string, Dictionary<string, ParameterValidator>> GetValidationRules() {
     return new Dictionary<string, Dictionary<string, ParameterValidator>> {
-      ["RunActor"] = new Dictionary<string, ParameterValidator> {
+      [OP_RUN_ACTOR_ID] = new Dictionary<string, ParameterValidator> {
         ["waitForFinish"] = ValidateWaitForFinish,
         ["timeout"] = ValidatePositiveInteger
       },
-      ["RunTask"] = new Dictionary<string, ParameterValidator> {
+      [OP_RUN_TASK_ID] = new Dictionary<string, ParameterValidator> {
         ["waitForFinish"] = ValidateWaitForFinish,
         ["timeout"] = ValidatePositiveInteger
       },
-      ["ScrapeSingleUrl"] = new Dictionary<string, ParameterValidator> {
+      [OP_SCRAPE_SINGLE_URL_ID] = new Dictionary<string, ParameterValidator> {
         ["url"] = ValidateUrl
       },
-      ["GetDatasetItems"] = new Dictionary<string, ParameterValidator> {
+      [OP_GET_DATASET_ITEMS_ID] = new Dictionary<string, ParameterValidator> {
         ["limit"] = ValidatePositiveInteger,
         ["offset"] = ValidateNonNegativeInteger
       }

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -15,7 +15,7 @@ echo "Validating apiDefinition.swagger.json..."
 jq -e '.swagger and .info and .info.title and .info.version and .host and .basePath' ./apiDefinition.swagger.json > /dev/null || { echo "Error: apiDefinition.swagger.json is invalid or missing required fields"; exit 1; }
 
 echo "Validating apiProperties.json..."
-jq -e '.properties and .properties.connectionParameters and .properties.capabilities' ./apiProperties.json > /dev/null || { echo "Error: apiProperties.json is invalid or missing required fields"; exit 1; }
+jq -e '.properties and .properties.connectionParameters' ./apiProperties.json > /dev/null || { echo "Error: apiProperties.json is invalid or missing required fields"; exit 1; }
 
 # Check script contains required class
 echo "Validating scripts.csx..."


### PR DESCRIPTION
Implementing the missing validation of some of the input query parameters that the Power Automate does not check.

For now, the objects/enums are checked before storing/running the flow. But due to limitations of Swagger 2.0 and Power Automate, there is no way to check the format of number fields or string fields (like URL).

I've created a validation logic that should be easy/modular to use, and add new logic for validation if necessary in the future.

The only file changed is the scripts.csx.