### PR TITLE
Feat: Power Automate Final Edits

### DIFF
--- a/apiDefinition.swagger.json
+++ b/apiDefinition.swagger.json
@@ -1715,41 +1715,37 @@
     "OnRunSucceededParameter": {
       "name": "onRunSucceeded",
       "x-ms-summary": "Trigger On Run Succeeded",
-      "description": "Trigger when an Actor run succeeds. Defaults to false if not set.",
+      "description": "Trigger when an Actor run succeeds. Defaults to true if not set.",
       "in": "query",
       "required": false,
       "type": "boolean",
-      "default": true,
       "x-ms-visibility": "important"
     },
     "OnRunFailedParameter": {
       "name": "onRunFailed",
       "x-ms-summary": "Trigger On Run Failed",
-      "description": "Trigger when an Actor run fails. Defaults to false if not set.",
+      "description": "Trigger when an Actor run fails. Defaults to true if not set.",
       "in": "query",
       "required": false,
       "type": "boolean",
-      "default": false,
       "x-ms-visibility": "important"
     },
     "OnRunTimedOutParameter": {
       "name": "onRunTimedOut",
       "x-ms-summary": "Trigger On Run Timed Out",
-      "description": "Trigger when an Actor run times out. Defaults to false if not set.",
+      "description": "Trigger when an Actor run times out. Defaults to true if not set.",
       "in": "query",
       "required": false,
       "type": "boolean",
-      "default": false,
       "x-ms-visibility": "important"
     },
     "OnRunAbortedParameter": {
       "name": "onRunAborted",
       "x-ms-summary": "Trigger On Run Aborted",
-      "description": "Trigger when an Actor run is aborted. Defaults to false if not set.",
+      "description": "Trigger when an Actor run is aborted. Defaults to true if not set.",
       "in": "query",
       "required": false,
       "type": "boolean",
-      "default": false,
       "x-ms-visibility": "important"
     }
   },

--- a/apiDefinition.swagger.json
+++ b/apiDefinition.swagger.json
@@ -1024,6 +1024,29 @@
             "$ref": "#/parameters/IntegrationPlatformHeader"
           },
           {
+            "name": "actorScope",
+            "x-ms-summary": "Select Actor from",
+            "description": "Please select the source to search Actors from.",
+            "default": "RecentActors",
+            "in": "query",
+            "required": true,
+            "type": "string",
+            "enum": [
+              "RecentActors",
+              "StoreActors"
+            ],
+            "x-ms-enum-values": [
+              {
+                "value": "RecentActors",
+                "displayName": "Recently used Actors"
+              },
+              {
+                "value": "StoreActors",
+                "displayName": "Apify Store Actors"
+              }
+            ]
+          },
+          {
             "name": "body",
             "in": "body",
             "required": true,
@@ -1096,29 +1119,6 @@
                 "condition"
               ]
             }
-          },
-          {
-            "name": "actorScope",
-            "x-ms-summary": "Select Actor from",
-            "description": "Please select the source to search Actors from.",
-            "default": "RecentActors",
-            "in": "query",
-            "required": true,
-            "type": "string",
-            "enum": [
-              "RecentActors",
-              "StoreActors"
-            ],
-            "x-ms-enum-values": [
-              {
-                "value": "RecentActors",
-                "displayName": "Recently used Actors"
-              },
-              {
-                "value": "StoreActors",
-                "displayName": "Apify Store Actors"
-              }
-            ]
           },
           {
             "$ref": "#/parameters/OnRunSucceededParameter"

--- a/apiDefinition.swagger.json
+++ b/apiDefinition.swagger.json
@@ -154,10 +154,10 @@
     },
     "/store": {
       "get": {
-        "summary": "List store Actors (for dropdown)",
+        "summary": "List Store Actors (for dropdown)",
         "description": "Fetches a list of Actors from the Apify store.",
         "operationId": "ListStoreActors",
-        "x-ms-summary": "List store Actors (for dropdown)",
+        "x-ms-summary": "List Store Actors (for dropdown)",
         "x-ms-visibility": "internal",
         "tags": [
           "Actors"
@@ -225,7 +225,7 @@
               },
               {
                 "value": "StoreActors",
-                "displayName": "Apify store Actors"
+                "displayName": "Apify Store Actors"
               }
             ],
             "description": "Please select the source to search Actors from.",
@@ -296,7 +296,7 @@
               },
               {
                 "value": "StoreActors",
-                "displayName": "Apify store Actors"
+                "displayName": "Apify Store Actors"
               }
             ]
           },
@@ -1042,7 +1042,7 @@
               },
               {
                 "value": "StoreActors",
-                "displayName": "Apify store Actors"
+                "displayName": "Apify Store Actors"
               }
             ]
           },

--- a/apiDefinition.swagger.json
+++ b/apiDefinition.swagger.json
@@ -1024,29 +1024,6 @@
             "$ref": "#/parameters/IntegrationPlatformHeader"
           },
           {
-            "name": "actorScope",
-            "x-ms-summary": "Select Actor from",
-            "description": "Please select the source to search Actors from.",
-            "default": "RecentActors",
-            "in": "query",
-            "required": true,
-            "type": "string",
-            "enum": [
-              "RecentActors",
-              "StoreActors"
-            ],
-            "x-ms-enum-values": [
-              {
-                "value": "RecentActors",
-                "displayName": "Recently used Actors"
-              },
-              {
-                "value": "StoreActors",
-                "displayName": "Apify Store Actors"
-              }
-            ]
-          },
-          {
             "name": "body",
             "in": "body",
             "required": true,
@@ -1119,6 +1096,29 @@
                 "condition"
               ]
             }
+          },
+          {
+            "name": "actorScope",
+            "x-ms-summary": "Select Actor from",
+            "description": "Please select the source to search Actors from.",
+            "default": "RecentActors",
+            "in": "query",
+            "required": true,
+            "type": "string",
+            "enum": [
+              "RecentActors",
+              "StoreActors"
+            ],
+            "x-ms-enum-values": [
+              {
+                "value": "RecentActors",
+                "displayName": "Recently used Actors"
+              },
+              {
+                "value": "StoreActors",
+                "displayName": "Apify Store Actors"
+              }
+            ]
           },
           {
             "$ref": "#/parameters/OnRunSucceededParameter"
@@ -1715,9 +1715,9 @@
     "OnRunSucceededParameter": {
       "name": "onRunSucceeded",
       "x-ms-summary": "Trigger On Run Succeeded",
-      "description": "Trigger when an Actor run succeeds.",
+      "description": "Trigger when an Actor run succeeds. Defaults to false if not set.",
       "in": "query",
-      "required": true,
+      "required": false,
       "type": "boolean",
       "default": true,
       "x-ms-visibility": "important"
@@ -1725,9 +1725,9 @@
     "OnRunFailedParameter": {
       "name": "onRunFailed",
       "x-ms-summary": "Trigger On Run Failed",
-      "description": "Trigger when an Actor run fails.",
+      "description": "Trigger when an Actor run fails. Defaults to false if not set.",
       "in": "query",
-      "required": true,
+      "required": false,
       "type": "boolean",
       "default": false,
       "x-ms-visibility": "important"
@@ -1735,9 +1735,9 @@
     "OnRunTimedOutParameter": {
       "name": "onRunTimedOut",
       "x-ms-summary": "Trigger On Run Timed Out",
-      "description": "Trigger when an Actor run times out.",
+      "description": "Trigger when an Actor run times out. Defaults to false if not set.",
       "in": "query",
-      "required": true,
+      "required": false,
       "type": "boolean",
       "default": false,
       "x-ms-visibility": "important"
@@ -1745,9 +1745,9 @@
     "OnRunAbortedParameter": {
       "name": "onRunAborted",
       "x-ms-summary": "Trigger On Run Aborted",
-      "description": "Trigger when an Actor run is aborted.",
+      "description": "Trigger when an Actor run is aborted. Defaults to false if not set.",
       "in": "query",
-      "required": true,
+      "required": false,
       "type": "boolean",
       "default": false,
       "x-ms-visibility": "important"

--- a/apiDefinition.swagger.json
+++ b/apiDefinition.swagger.json
@@ -306,7 +306,7 @@
             "required": true,
             "type": "string",
             "x-ms-summary": "Actor",
-            "description": "Actor identifier to run. Supply Actor ID or Actor name.",
+            "description": "Actor identifier to run. Supply Actor ID.",
             "x-ms-dynamic-values": {
               "operationId": "ListActorsDropdown",
               "value-collection": "data/items",
@@ -1062,7 +1062,7 @@
                 },
                 "eventTypes": {
                   "type": "array",
-                  "x-ms-visibility": "important",
+                  "x-ms-visibility": "internal",
                   "x-ms-summary": "Statuses",
                   "description": "Actor run statuses to trigger on.",
                   "items": {
@@ -1082,7 +1082,7 @@
                       "type": "string",
                       "x-ms-visibility": "important",
                       "x-ms-summary": "Actor",
-                      "description": "Actor identifier to monitor. Supply Actor ID or Actor name.",
+                      "description": "Actor identifier to monitor. Supply Actor ID.",
                       "x-ms-dynamic-values": {
                         "operationId": "ListActorsDropdown",
                         "value-collection": "data/items",
@@ -1096,7 +1096,10 @@
                         }
                       }
                     }
-                  }
+                  },
+                  "required": [
+                    "actorId"
+                  ]
                 },
                 "idempotencyKey": {
                   "type": "string",
@@ -1113,10 +1116,21 @@
               },
               "required": [
                 "requestUrl",
-                "eventTypes",
                 "condition"
               ]
             }
+          },
+          {
+            "$ref": "#/parameters/OnRunSucceededParameter"
+          },
+          {
+            "$ref": "#/parameters/OnRunFailedParameter"
+          },
+          {
+            "$ref": "#/parameters/OnRunTimedOutParameter"
+          },
+          {
+            "$ref": "#/parameters/OnRunAbortedParameter"
           }
         ],
         "responses": {
@@ -1232,7 +1246,7 @@
                 },
                 "eventTypes": {
                   "type": "array",
-                  "x-ms-visibility": "important",
+                  "x-ms-visibility": "internal",
                   "x-ms-summary": "Statuses",
                   "description": "Actor run statuses to trigger on.",
                   "items": {
@@ -1260,7 +1274,10 @@
                         "value-title": "name"
                       }
                     }
-                  }
+                  },
+                  "required": [
+                    "actorTaskId"
+                  ]
                 },
                 "idempotencyKey": {
                   "type": "string",
@@ -1277,10 +1294,21 @@
               },
               "required": [
                 "requestUrl",
-                "eventTypes",
                 "condition"
               ]
             }
+          },
+          {
+            "$ref": "#/parameters/OnRunSucceededParameter"
+          },
+          {
+            "$ref": "#/parameters/OnRunFailedParameter"
+          },
+          {
+            "$ref": "#/parameters/OnRunTimedOutParameter"
+          },
+          {
+            "$ref": "#/parameters/OnRunAbortedParameter"
           }
         ],
         "responses": {
@@ -1683,6 +1711,46 @@
       "default": 1000,
       "x-ms-summary": "Limit",
       "description": "Maximum number of Actors to return."
+    },
+    "OnRunSucceededParameter": {
+      "name": "onRunSucceeded",
+      "x-ms-summary": "Trigger On Run Succeeded",
+      "description": "Trigger when an Actor run succeeds.",
+      "in": "query",
+      "required": true,
+      "type": "boolean",
+      "default": true,
+      "x-ms-visibility": "important"
+    },
+    "OnRunFailedParameter": {
+      "name": "onRunFailed",
+      "x-ms-summary": "Trigger On Run Failed",
+      "description": "Trigger when an Actor run fails.",
+      "in": "query",
+      "required": true,
+      "type": "boolean",
+      "default": false,
+      "x-ms-visibility": "important"
+    },
+    "OnRunTimedOutParameter": {
+      "name": "onRunTimedOut",
+      "x-ms-summary": "Trigger On Run Timed Out",
+      "description": "Trigger when an Actor run times out.",
+      "in": "query",
+      "required": true,
+      "type": "boolean",
+      "default": false,
+      "x-ms-visibility": "important"
+    },
+    "OnRunAbortedParameter": {
+      "name": "onRunAborted",
+      "x-ms-summary": "Trigger On Run Aborted",
+      "description": "Trigger when an Actor run is aborted.",
+      "in": "query",
+      "required": true,
+      "type": "boolean",
+      "default": false,
+      "x-ms-visibility": "important"
     }
   },
   "responses": {

--- a/apiDefinition.swagger.json
+++ b/apiDefinition.swagger.json
@@ -1011,7 +1011,7 @@
       },
       "post": {
         "summary": "Actor run finished",
-        "description": "Creates a webhook to subscribe to Actor run events. Triggers when the selected Actor run finishes with a specific status. See docs: https://docs.apify.com/api/v2/webhooks-post.",
+        "description": "Creates a webhook to subscribe to Actor run events. Triggers when the selected Actor run finishes with a specific status. If no statuses are selected, all statuses are enabled by default. See docs: https://docs.apify.com/api/v2/webhooks-post.",
         "operationId": "ActorRunFinishedTrigger",
         "x-ms-summary": "Actor run finished",
         "x-ms-visibility": "important",
@@ -1218,7 +1218,7 @@
       },
       "post": {
         "summary": "Actor task finished",
-        "description": "Creates a webhook to subscribe to Actor task run events. Triggers when the selected Actor task run finishes with a specific status. See docs: https://docs.apify.com/api/v2/webhooks-post.",
+        "description": "Creates a webhook to subscribe to Actor task run events. Triggers when the selected Actor task run finishes with a specific status. If no statuses are selected, all statuses are enabled by default. See docs: https://docs.apify.com/api/v2/webhooks-post.",
         "operationId": "ActorTaskFinishedTrigger",
         "x-ms-summary": "Actor task finished",
         "x-ms-visibility": "important",

--- a/apiDefinition.swagger.json
+++ b/apiDefinition.swagger.json
@@ -1011,7 +1011,7 @@
       },
       "post": {
         "summary": "Actor run finished",
-        "description": "Creates a webhook to subscribe to Actor run events. Triggers when the selected Actor run finishes with a specific status. If no statuses are selected, all statuses are enabled by default. See docs: https://docs.apify.com/api/v2/webhooks-post.",
+        "description": "Creates a webhook to subscribe to Actor run events. Triggers when the selected Actor run finishes with a specific status. All statuses are enabled by default; only statuses explicitly set to false are excluded. At least one status must remain enabled. See docs: https://docs.apify.com/api/v2/webhooks-post.",
         "operationId": "ActorRunFinishedTrigger",
         "x-ms-summary": "Actor run finished",
         "x-ms-visibility": "important",
@@ -1218,7 +1218,7 @@
       },
       "post": {
         "summary": "Actor task finished",
-        "description": "Creates a webhook to subscribe to Actor task run events. Triggers when the selected Actor task run finishes with a specific status. If no statuses are selected, all statuses are enabled by default. See docs: https://docs.apify.com/api/v2/webhooks-post.",
+        "description": "Creates a webhook to subscribe to Actor task run events. Triggers when the selected Actor task run finishes with a specific status. All statuses are enabled by default; only statuses explicitly set to false are excluded. At least one status must remain enabled. See docs: https://docs.apify.com/api/v2/webhooks-post.",
         "operationId": "ActorTaskFinishedTrigger",
         "x-ms-summary": "Actor task finished",
         "x-ms-visibility": "important",

--- a/scripts.csx
+++ b/scripts.csx
@@ -566,9 +566,9 @@ public class Script : ScriptBase {
         try {
           body = JObject.Parse(bodyString);
         } catch (JsonReaderException) {
-          var errorResponse = new HttpResponseMessage(HttpStatusCode.BadRequest);
-          errorResponse.Content = CreateJsonContent("Request body must be a valid JSON object.");
-          return errorResponse;
+          var validation = new ValidationResult();
+          validation.AddError("Request body must be a valid JSON object.");
+          return CreateValidationErrorResponse(validation);
         }
       }
     }
@@ -590,11 +590,9 @@ public class Script : ScriptBase {
     var queryParams = System.Web.HttpUtility.ParseQueryString(originalUri.Query);
 
     var eventTypes = BuildEventTypesFromQuery(queryParams);
-    // If no event types are selected, return a bad request error
+    // If no event types are selected, default to all event types
     if (eventTypes.Count == 0) {
-      var errorResponse = new HttpResponseMessage(HttpStatusCode.BadRequest);
-      errorResponse.Content = CreateJsonContent("At least one trigger status must be enabled.");
-      return errorResponse;
+      eventTypes.AddRange(StatusParamToEventType.Values);
     }
 
     foreach (var param in extraParamsToRemove) {

--- a/scripts.csx
+++ b/scripts.csx
@@ -275,26 +275,9 @@ public class Script : ScriptBase {
   /// <param name="index">Index of the item</param>
   /// <returns>A numerical prefix string</returns>
   private static string GetNumericalPrefix(int totalItems, int index) {
-    if (totalItems <= 0) return string.Empty;
-    if (index < 0 || index >= totalItems) return string.Empty;
-
-    // Determine how many digits are needed: smallest n where 10^n > totalItems
-    int prefixLength = 1;
-    long capacity = 10;
-    while (capacity <= totalItems) {
-      capacity *= 10;
-      prefixLength++;
-    }
-
-    // Convert index to decimal digits
-    int value = index + 1;
-    char[] prefix = new char[prefixLength];
-    for (int i = prefixLength - 1; i >= 0; i--) {
-      prefix[i] = (char)('0' + (value % 10));
-      value /= 10;
-    }
-
-    return new string(prefix);
+    if (totalItems <= 0 || index < 0 || index >= totalItems) return string.Empty;
+    int width = totalItems.ToString().Length;
+    return (index + 1).ToString().PadLeft(width, '0');
   }
 
   /// <summary>
@@ -305,7 +288,7 @@ public class Script : ScriptBase {
   /// <param name="items">The JArray of items to format</param>
   /// <param name="formatter">Function to apply formatting to each JObject item</param>
   /// <param name="displayField">The JSON field name to prepend the numerical prefix to</param>
-  private void FormatItems(JArray items, Action<JObject> formatter, string displayField) {
+  private static void FormatItems(JArray items, Action<JObject> formatter, string displayField) {
     if (items == null || items.Count == 0) return;
 
     for (int i = 0; i < items.Count; i++) {
@@ -321,7 +304,7 @@ public class Script : ScriptBase {
   /// Formats actor titles by combining title, username, and name for better user experience.
   /// </summary>
   /// <param name="item">The JObject representing an actor item</param>
-  private void FormatActorTitle(JObject item) {
+  private static void FormatActorTitle(JObject item) {
     var title = item["title"]?.Value<string>();
     var name = item["name"]?.Value<string>();
     var username = item["username"]?.Value<string>();
@@ -338,7 +321,7 @@ public class Script : ScriptBase {
   /// Formats task names by combining name and actName for better user experience.
   /// </summary>
   /// <param name="item">The JObject representing a task item</param>
-  private void FormatTaskTitle(JObject item) {
+  private static void FormatTaskTitle(JObject item) {
     var name = item["name"]?.Value<string>();
     var actName = item["actName"]?.Value<string>();
 

--- a/scripts.csx
+++ b/scripts.csx
@@ -227,7 +227,7 @@ public class Script : ScriptBase {
   /// <returns>A new HttpResponseMessage with the formatted content</returns>
   private async Task<HttpResponseMessage> FormatApiResponse(HttpResponseMessage response, Action<JArray> formatAction) {
     if (!response.IsSuccessStatusCode) {
-      return response; // Return error responses as-is
+      return response;
     }
 
     // Read and parse the JSON response

--- a/scripts.csx
+++ b/scripts.csx
@@ -641,10 +641,10 @@ public class Script : ScriptBase {
 
   /// <summary>
   /// Handles task webhook deletion by routing to standard webhooks endpoint.
-  /// Routes /webhooks/task/{webhookId} to /webhooks/{webhookId} and applies robust deletion handling.
+  /// Routes /webhooks/task/ to /webhooks/ and converts 204 to 200.
   /// </summary>
   private async Task<HttpResponseMessage> HandleDeleteTaskWebhook() {
-    ModifyRequestPath("/webhooks/task/{webhookId}", "/webhooks/{webhookId}");
+    ModifyRequestPath("/webhooks/task/", "/webhooks/");
 
     return await HandleDeleteWebhook().ConfigureAwait(false);
   }


### PR DESCRIPTION
Changes:

- **Preserve dropdown sort order** 
  - Zero-padded numerical prefixes (e.g., `001)`, `002)`) to Actor and Task display names so Power Automate dropdowns maintain the API-returned order.
- **Refactor webhook event types into boolean toggles** 
  - Replace the hidden `eventTypes` array with four user-facing boolean parameters (`onRunSucceeded`, `onRunFailed`, `onRunTimedOut`, `onRunAborted`). The C# script converts these into the `eventTypes` array before forwarding to the Apify API.
- **UI fixes** 
  - Capitalize "Store" consistently, simplify actor description text, and make `actorId`/`actorTaskId` required in webhook triggers.
  


- **safer Json parsing**
  - Handling json parsing more carefully
- **cached dictioinary**
  - minor tweak to reused declared dictionary

What hasn't been fixed:
- Order of input fields
  - Microsoft PA doesn't allow custom order of input fields, so we have Actor input field before the Select Actor from field  