### PR TITLE
fix: add policy template instance for apify integration platform head…

### DIFF
--- a/apiProperties.json
+++ b/apiProperties.json
@@ -40,6 +40,18 @@
       }
     },
     "iconBrandColor": "#246dff",
+    "policyTemplateInstances": [
+      {
+        "templateId": "setheader",
+        "title": "Set Apify Integration Platform Header",
+        "parameters": {
+          "x-ms-apimTemplateParameter.name": "x-apify-integration-platform",
+          "x-ms-apimTemplateParameter.value": "microsoft-power-automate",
+          "x-ms-apimTemplateParameter.existsAction": "skip",
+          "x-ms-apimTemplate-policySection": "Request"
+        }
+      }
+    ],
     "publisher": "Apify",
     "stackOwner": "Apify"
   }


### PR DESCRIPTION
## Summary

- Restores `policyTemplateInstances` in `apiProperties.json` to fix Microsoft cert error **5000.1.1.16** returned for the May submission.
- Root cause was a manifest vs content mismatch in the exported solution after fix #32 of the previous cert PR removed the `setheader` policy.

## Background

The previous PR (`fix/power-automate-certification-5000-2-6-2`) removed the `setheader` `policyTemplateInstances` block from `apiProperties.json` as fix #32. It was assumed safe to drop since the same `x-apify-integration-platform` header is sent at runtime via the swagger `IntegrationPlatformHeader` parameter.

That broke the exported solution:

- with `policyTemplateInstances` empty in `apiProperties.json`, the exported `policytemplateinstances.json` is 2 bytes (`[]`)
- but `customizations.xml` inside the solution still references `<policytemplateinstances>/Connector/new_apify_policytemplateinstances.json</policytemplateinstances>` (Power Apps emits this reference unconditionally regardless of the file's content)
- Microsoft's cert validator treats this manifest-vs-content mismatch as `Invalid package. Solution not present at correct path or is invalid solution.` (policy code 5000.1.1.16)

Verified empirically:
- April submission: `policytemplateinstances.json` = 311 bytes → passed cert
- May submission: `policytemplateinstances.json` = 2 bytes → rejected with 5000.1.1.16

## Fix

Restored the `setheader` block in `apiProperties.json`:

```json
"policyTemplateInstances": [
  {
    "templateId": "setheader",
    "title": "Set Apify Integration Platform Header",
    "parameters": {
      "x-ms-apimTemplateParameter.name": "x-apify-integration-platform",
      "x-ms-apimTemplateParameter.value": "microsoft-power-automate",
      "x-ms-apimTemplateParameter.existsAction": "skip",
      "x-ms-apimTemplate-policySection": "Request"
    }
  }
]