### PR TITLE
docs: update introduction and README for clarity and accuracy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Apify Connector
 
-Apify is a web scraping platform. Use this connector to run scrapers (called Actors), fetch results from datasets and key-value stores, and trigger flows when scraping jobs finish.
+Apify is the largest marketplace of tools for AI. Use this connector to run Apify tools (called Actors), fetch results from datasets and key-value stores, and trigger flows when runs finish.
 
-## Quick Start
+## Quick start
 
 1. **Sign up** for an Apify account at [console.apify.com](https://console.apify.com/)
 2. **Add the connector** to your Power Automate flow
@@ -11,31 +11,33 @@ Apify is a web scraping platform. Use this connector to run scrapers (called Act
 
 For detailed instructions, visit the [Apify Microsoft Power Automate documentation](https://docs.apify.com/platform/integrations/microsoft-power-automate).
 
-## Key Capabilities
+## Key capabilities
 
 **Triggers:**
-- **[Actor Run Finished](#actor-run-finished):** Start a flow when an Actor completes
-- **[Actor Task Finished](#actor-task-finished):** Start a flow when a Task completes
+
+- **[Actor run finished](#actor-run-finished):** Start a flow when an Actor completes
+- **[Actor task finished](#actor-task-finished):** Start a flow when a Task completes
 
 **Actions:**
+
 - **[Run Actor](#run-actor):** Execute any Apify Actor
-- **[Run Task](#run-task):** Execute a saved Actor Task
-- **[Get Dataset Items](#get-dataset-items):** Retrieve scraped data from datasets
-- **[Get Key-Value Store Record](#get-key-value-store-record):** Fetch stored data
-- **[Scrape Single URL](#scrape-single-url):** Quick single-page scraping
+- **[Run task](#run-task):** Execute a saved Actor task
+- **[Get dataset items](#get-dataset-items):** Retrieve scraped data from datasets
+- **[Get key-value store record](#get-key-value-store-record):** Fetch stored data
+- **[Scrape single URL](#scrape-single-url):** Quick single-page scraping
 
 ## Prerequisites
 
 Before using this connector, you need:
 
-- An Apify account. Sign up at the [Apify Console](https://console.apify.com/).
+- An Apify account. Sign up in [Apify Console](https://console.apify.com/).
 
 ## Authentication
 
 The connector supports **OAuth 2.0** authentication with the following scopes:
 
 - `profile`: Read your Apify username and account ID to identify the connection.
-- `full_api_access`: Run Actors, start Tasks, read Datasets and Key-Value Stores, and manage webhooks.
+- `full_api_access`: Run Actors, start tasks, read datasets and key-value stores, and manage webhooks.
 
 When creating a connection in Power Automate, select *Sign in with Apify*. You will be redirected to Apify to authorize access to your account.
 
@@ -43,91 +45,95 @@ When creating a connection in Power Automate, select *Sign in with Apify*. You w
 
 ## Triggers
 
-> **Note:** Triggers create webhooks in your Apify account to notify Power Automate. When you delete or disable a flow, manually remove the associated webhooks in the [Apify Console](https://console.apify.com/) to keep your account organized. We are working on automating this cleanup in the future.
+> **Note:** Triggers create webhooks in your Apify account to notify Power Automate. When you delete or disable a flow, manually remove the associated webhooks in Apify Console to keep your account organized. We are working on automating this cleanup in the future.
 
-### Actor Run Finished
+### Actor run finished
 
 Use the *Actor run finished* trigger to automatically execute your Power Automate flow when a specific Apify Actor run completes with a selected status.
 
 - **Authentication:** Use *Sign in with Apify* [OAuth 2.0] (scopes: `profile`, `full_api_access`).
 - **Headers:** `x-apify-integration-platform: microsoft-power-automate`.
 - **Inputs:**
-  - `Actor Scope`: Choose between *Recently used Actors* or *From store* (Apify store Actors).
-  - `Actor`: Dynamic dropdown populated with Actors based on the selected scope.
-  - `Trigger On`: Select which run statuses should trigger the flow (SUCCEEDED, FAILED, TIMED_OUT, ABORTED).
+    - `Actor Scope`: Choose between *Recently used Actors* or *From store* (Apify store Actors).
+    - `Actor`: Dynamic dropdown populated with Actors based on the selected scope.
+    - `Trigger On`: Select which run statuses should trigger the flow (SUCCEEDED, FAILED, TIMED_OUT, ABORTED).
 - **Output:** Webhook payload containing detailed information about the completed Actor run.
 
 **How it works:**
+
 - Actor dropdown is populated via `GET /v2/acts` (for recent Actors) or via `GET /v2/store` store API (for store Actors).
 - The trigger creates a webhook via `POST /v2/webhooks` that subscribes to Actor run events.
 - When the selected Actor finishes with one of the specified statuses, Apify sends a webhook payload to Power Automate.
 
-### Actor Task Finished
+### Actor task finished
 
 Use the *Actor task finished* trigger to automatically execute your Power Automate flow when a specific Apify Actor task run completes with a selected status.
 
 - **Authentication:** Use *Sign in with Apify* [OAuth 2.0] (scopes: `profile`, `full_api_access`).
 - **Headers:** `x-apify-integration-platform: microsoft-power-automate`.
 - **Inputs:**
-  - `Task`: Dynamic dropdown populated with your Actor tasks.
-  - `Trigger On`: Select which run statuses should trigger the flow (SUCCEEDED, FAILED, TIMED_OUT, ABORTED).
+    - `Task`: Dynamic dropdown populated with your Actor tasks.
+    - `Trigger On`: Select which run statuses should trigger the flow (SUCCEEDED, FAILED, TIMED_OUT, ABORTED).
 - **Output:** Webhook payload containing detailed information about the completed task run.
 
 **How it works:**
+
 - Creates a webhook via `POST /v2/webhooks` that subscribes to Actor task run events.
 - Task dropdown is populated via `GET /v2/actor-tasks` to list your available tasks.
 
 ## Actions
 
-### Get Dataset Items
+### Get dataset items
 
 Use the *Get dataset items* action to retrieve records from one of your Apify datasets.
 
 - **Authentication:** Use *Sign in with Apify* [OAuth 2.0] (scopes: `profile`, `full_api_access`).
 - **Headers:** `x-apify-integration-platform: microsoft-power-automate`.
 - **Inputs:**
-  - `Dataset`: Select a dataset from a dynamically populated dropdown of your datasets.
-  - `Limit` (optional): Number of items to return.
-  - `Offset` (optional): Number of items to skip (for pagination).
+    - `Dataset`: Select a dataset from a dynamically populated dropdown of your datasets.
+    - `Limit` (optional): Number of items to return.
+    - `Offset` (optional): Number of items to skip (for pagination).
 - **Output:** An array of dataset items. The item shape is dynamic and depends on the selected dataset.
 
 **How it works:**
+
 - The dataset dropdown is populated via `GET /v2/datasets` so you can pick by name.
 - The connector calls `GET /v2/datasets/{datasetId}/items` with the provided `limit` and `offset` to fetch the data.
 - To provide typed fields in Power Automate, it calls `GET /v2/datasets/{datasetId}/itemsSchemaHelper` to infer the item schema from a sample.
 
 **Tips:**
+
 - For large datasets, paginate using `limit` and `offset` to process items in batches.
 
-### Get Key-Value Store Record
+### Get key-value store record
 
 Retrieve a record's content from a selected key-value store.
 
 - **Authentication:** Use *Sign in with Apify* [OAuth 2.0] (scopes: `profile`, `full_api_access`).
 - **Headers:** `x-apify-integration-platform: microsoft-power-automate`.
 - **Inputs:**
-  - `Store` (`storeId`, required): Dynamic dropdown listing your stores.
-  - `Record Key` (`recordKey`, required): Dependent dropdown listing keys for the selected store.
+    - `Store` (`storeId`, required): Dynamic dropdown listing your stores.
+    - `Record Key` (`recordKey`, required): Dependent dropdown listing keys for the selected store.
 - **Output:**
-  - Body: Raw record content (handled as binary; text and JSON are shown accordingly by Power Automate).
-  - Header: `Content-Type` is exposed as an output value.
+    - Body: Raw record content (handled as binary; text and JSON are shown accordingly by Power Automate).
+    - Header: `Content-Type` is exposed as an output value.
 
 This action calls `GET /v2/key-value-stores/{storeId}/records/{recordKey}` via Apify API proxy.
 
-### Scrape Single URL
+### Scrape single URL
 
 Use the *Scrape single URL* action to scrape a single webpage using Apify's Web Scraper Actor.
 
 - **Authentication:** Use *Sign in with Apify* [OAuth 2.0] (scopes: `profile`, `full_api_access`).
 - **Headers:** `x-apify-integration-platform: microsoft-power-automate`.
 - **Inputs:**
-  - `URL`: The full URL of the single page to be scraped. Must be a valid URL format.
-  - `Crawler Type`: Select the crawling engine to use:
-    - `playwright:adaptive` (Adaptive - recommended)
-    - `playwright:firefox` (Firefox Headless Browser)
-    - `cheerio` (Cheerio - Raw HTTP, fastest)
+    - `URL`: The full URL of the single page to be scraped. Must be a valid URL format.
+    - `Crawler Type`: Select the crawling engine to use:
+        - `playwright:adaptive` (Adaptive - recommended)
+        - `playwright:firefox` (Firefox headless browser)
+        - `cheerio` (Cheerio - Raw HTTP, fastest)
 
-The connector invokes `POST /v2/acts/aYG0l9s7dbB7j3gbS/runs` (Web Scraper Actor). This action returns the run details immediately. To process results, use the *Actor Run Finished* trigger.
+The connector uses the Apify Web Scraper Actor internally. This action returns the run details immediately. To process results, use the *Actor Run Finished* trigger.
 
 ### Run Actor
 
@@ -136,45 +142,45 @@ Use the *Run Actor* action to start an Apify Actor run.
 - **Authentication:** Use *Sign in with Apify* [OAuth 2.0] (scopes: `profile`, `full_api_access`).
 - **Headers:** `x-apify-integration-platform: microsoft-power-automate`.
 - **Inputs:**
-  - `Actor Scope`: Choose *Recently used Actors* or *From store*.
-    - If *Recently used Actors*: pick from `Actor` populated by your account Actors.
-    - If *From store*: pick from `Actor` populated by Apify Store (limit 1000).
-  - `Input Body`: Provide JSON for the Actor input.
-  - `Build` (optional): Specific build tag or id.
-  - `Timeout` (optional): Timeout in seconds.
-  - `Memory` (optional): Memory in MB (128, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768).
-  - `Wait for Finish` (optional): Wait time in seconds (max 60). Set 0 to return immediately.
+    - `Actor Scope`: Choose *Recently used Actors* or *From store*.
+        - If *Recently used Actors*: pick from `Actor` populated by your account Actors.
+        - If *From store*: pick from `Actor` populated by Apify Store (limit 1,000).
+    - `Input Body`: Provide JSON for the Actor input.
+    - `Build` (optional): Specific build tag or id.
+    - `Timeout` (optional): Timeout in seconds.
+    - `Memory` (optional): Memory in MB (128, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768).
+    - `Wait for Finish` (optional): Wait time in seconds (max 60). Set 0 to return immediately.
 
-The connector invokes `POST /v2/acts/{actorId}/runs` per [Apify docs](https://docs.apify.com/api/v2/act-runs-post). The `actorId` path segment is chosen automatically based on your `actorScope` selection.
+The connector invokes `POST /v2/acts/{actorId}/runs` per Apify docs. The `actorId` path segment is chosen automatically based on your `actorScope` selection.
 
-> **Note:** Available memory options depend on your Apify subscription plan. For more information, see your [account limits](https://console.apify.com/billing/limits).
+> **Note:** Available memory options depend on your Apify subscription plan. For more information, see your account limits.
 
-### Run Task
+### Run task
 
 Use the *Run task* action to start an Apify task run.
 
 - **Authentication:** Use *Sign in with Apify* [OAuth 2.0] (scopes: `profile`, `full_api_access`).
 - **Headers:** `x-apify-integration-platform: microsoft-power-automate`.
 - **Inputs:**
-  - `Task`: Select the task from a dynamic dropdown of your available tasks.
-  - `Input Body` (optional): Provide a raw JSON object to override the task's default input.
-  - `Timeout` (optional): Timeout in seconds.
-  - `Build` (optional): Specific build tag or id.
-  - `Memory` (optional): Memory in MB (128, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768).
-  - `Wait for Finish` (optional): Wait time in seconds (max 60). If empty or 0, the call is asynchronous.
+    - `Task`: Select the task from a dynamic dropdown of your available tasks.
+    - `Input Body` (optional): Provide a raw JSON object to override the task's default input.
+    - `Timeout` (optional): Timeout in seconds.
+    - `Build` (optional): Specific build tag or id.
+    - `Memory` (optional): Memory in MB (128, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768).
+    - `Wait for Finish` (optional): Wait time in seconds (max 60). If empty or 0, the call is asynchronous.
 
-The connector invokes `POST /v2/actor-tasks/{taskId}/runs` per [Apify docs](https://docs.apify.com/api/v2/actor-task-runs-post). The `taskId` path segment is selected directly from the dropdown.
+The connector invokes `POST /v2/actor-tasks/{taskId}/runs` per Apify docs. The `taskId` path segment is selected directly from the dropdown.
 
-> **Note:** Available memory options depend on your Apify subscription plan. For more information, see your [account limits](https://console.apify.com/billing/limits).
+> **Note:** Available memory options depend on your Apify subscription plan. For more information, see your account limits.
 
-## Common Use Cases
+## Common use cases
 
 - **Price drop alerts:** Run a price scraper on a schedule, then notify via Teams when prices drop
 - **CRM enrichment:** Scrape company websites and push the data to Dynamics 365 or SharePoint
 - **Competitor tracking:** Detect changes on competitor pages and log them to Excel
 - **Lead generation:** Scrape directories, filter results, and add leads to your CRM
 
-## Known Issues and Limitations
+## Known issues and limitations
 
 - The *Wait for Finish* parameter has a maximum value of **60 seconds**. For long-running Actors, use webhooks (triggers) instead of waiting.
 - The connector infers dataset schemas from sample data. This may not capture all possible fields.
@@ -184,27 +190,32 @@ The connector invokes `POST /v2/actor-tasks/{taskId}/runs` per [Apify docs](http
 ## Troubleshooting
 
 **Trigger not firing?**
-- Verify the webhook was created in [Apify Console → Webhooks](https://console.apify.com/)
+
+- Verify the webhook was created in Apify Console → Webhooks
 - Check that the Actor/Task is running and completing with the selected status
 - Ensure your flow is enabled and saved
 
 **Authentication errors?**
+
 - Re-authenticate by creating a new connection in Power Automate
 - Verify your Apify account has the required permissions
 
 **Dataset items missing fields?**
+
 - The connector infers schema from sample data; some fields may not appear if they're absent in the sample
 - Use raw JSON output if you need all fields regardless of schema
 
 **Webhook cleanup?**
-- When you delete or disable a flow, manually remove associated webhooks from [Apify Console](https://console.apify.com/)
 
-## Frequently Asked Questions
+- When you delete or disable a flow, manually remove associated webhooks from Apify Console
+
+## FAQ
 
 **How much does it cost?**
-The connector is free. Apify charges for compute (runtime, memory, proxies). There's a free tier with monthly credits. For pricing details, visit [apify.com/pricing](https://apify.com/pricing).
+The connector is free. Apify charges for compute (runtime, memory, proxies). There's a free tier with monthly usage. For pricing details, visit [apify.com/pricing](https://apify.com/pricing).
 
 **Where can I get help?**
+
 - **Apify documentation:** [docs.apify.com](https://docs.apify.com)
 - **API reference:** [docs.apify.com/api/v2](https://docs.apify.com/api/v2)
 - **Apify store:** [apify.com/store](https://apify.com/store)
@@ -213,9 +224,9 @@ The connector is free. Apify charges for compute (runtime, memory, proxies). The
 
 ## Contributing
 
-For developers contributing to or customizing this connector, see the [Developer Guide](CONTRIBUTING.md).
+For developers contributing to or customizing this connector, see the Developer Guide.
 
 ---
 
 **Maintained by:** Apify Team
-**Support:** [GitHub Issues](https://github.com/apify/apify-microsoft-power-automate-integration/issues)
+**Support:** GitHub Issues

--- a/README.md
+++ b/README.md
@@ -224,9 +224,9 @@ The connector is free. Apify charges for compute (runtime, memory, proxies). The
 
 ## Contributing
 
-For developers contributing to or customizing this connector, see the Developer Guide.
+For developers contributing to or customizing this connector, see the [Developer Guide](CONTRIBUTING.md).
 
 ---
 
 **Maintained by:** Apify Team
-**Support:** GitHub Issues
+**Support:** [GitHub Issues](https://github.com/apify/apify-microsoft-power-automate-integration/issues)

--- a/intro.md
+++ b/intro.md
@@ -1,6 +1,6 @@
 # Apify
 
-Apify is a full-stack web scraping and automation platform. The Apify connector for Power Automate lets you run web scrapers and AI agents (called Actors), execute pre-configured tasks, retrieve structured data from datasets and key-value stores, and trigger automated workflows when jobs finish. Over 4,000 ready-made Actors are available on the Apify Store for common scraping and automation use cases.
+Apify is the largest marketplace of tools for AI. The Apify connector for Power Automate lets you run web scrapers and AI agents (called Actors), execute pre-configured tasks, retrieve structured data from datasets and key-value stores, and trigger automated workflows when jobs finish. Over 30,000 ready-made Actors are available on Apify Store for common scraping and automation use cases.
 
 ## Publisher
 
@@ -8,20 +8,20 @@ Apify Technologies s.r.o.
 
 ## Prerequisites
 
-- **An Apify account** — sign up for free at [apify.com](https://apify.com). A free tier with monthly platform credits is included.
-- **OAuth 2.0 authorization** — the connector authenticates through Apify's OAuth flow. No API tokens or manual credential setup is needed from end users.
+- **An Apify account** - sign up for free at [apify.com](https://apify.com). A free tier with monthly platform credits is included.
+- **OAuth 2.0 authorization** - the connector authenticates through Apify's OAuth flow. No API tokens or manual credential setup is needed from end users.
 
 ## How to get credentials
 
-The connector uses OAuth 2.0 authentication. When you add the Apify connector to a flow and create a new connection, you are automatically redirected to the Apify Console to authorize access. Follow these steps:
+The connector uses OAuth 2.0 authentication. When you add the Apify connector to a flow and create a new connection, you are automatically redirected to Apify Console to authorize access. Follow these steps:
 
 1. In your Power Automate flow, add any Apify action or trigger.
 2. When prompted to create a connection, click **Sign in**.
-3. You will be redirected to the **Apify Console** authorization page at `console.apify.com`.
+3. You will be redirected to **Apify Console** authorization page at [`console.apify.com`](https://console.apify.com/).
 4. If you are not logged in to Apify, enter your Apify account email and password (or use Google/GitHub sign-in).
 5. Review the requested permissions:
-   - **profile** — access to your user profile information
-   - **full_api_access** — full access to the Apify API on your behalf
+    - **profile** - access to your user profile information
+    - **full_api_access** - full access to the Apify API on your behalf
 6. Click **Authorize** to grant the connector access.
 7. You will be redirected back to Power Automate with an active connection.
 
@@ -29,15 +29,15 @@ No manual entry of API tokens, client IDs, or secrets is required from end users
 
 ### For the Microsoft certification review team
 
-To test the connector, you will need an Apify account. You can create one for free at [apify.com](https://apify.com) — no credit card is required. The free tier includes enough platform credits to run test Actors and verify all connector operations. After creating an account, follow steps 1–7 above to authorize the connector.
+To test the connector, you will need an Apify account. You can create one for free at [apify.com](https://apify.com) - no credit card is required. The free tier includes enough platform credits to run test Actors and verify all connector operations. After creating an account, follow steps 1-7 above to authorize the connector.
 
 ## Supported operations
 
 ### Actions
 
 | Operation | Description |
-|-----------|-------------|
-| **Run Actor** | Runs an Apify Actor with the specified input. You can select from recently used Actors or browse the Apify Store. Optionally wait up to 60 seconds for the run to finish. Returns run metadata including status, dataset ID, and key-value store ID. |
+| --- | --- |
+| **Run Actor** | Runs an Apify Actor with the specified input. You can select from recently used Actors or browse Apify Store. Optionally wait up to 60 seconds for the run to finish. Returns run metadata including status, dataset ID, and key-value store ID. |
 | **Run task** | Runs a pre-configured Actor task. Tasks store default input configurations so you can execute them without specifying input each time. Optionally override the default input with custom values. |
 | **Scrape single URL** | Scrapes a single web page using the Apify Web Scraper Actor. Choose between adaptive (recommended), Firefox headless browser, or Cheerio (raw HTTP) crawling modes. Returns the run metadata for tracking. |
 | **Get dataset items** | Retrieves items from an Apify dataset. Datasets store structured results from Actor runs. Supports pagination with limit and offset parameters. The response schema is dynamically inferred from the dataset contents. |
@@ -46,7 +46,7 @@ To test the connector, you will need an Apify account. You can create one for fr
 ### Triggers
 
 | Operation | Description |
-|-----------|-------------|
+| --- | --- |
 | **Actor run finished** | Fires when a selected Actor run finishes. Subscribe to specific completion statuses: succeeded, failed, timed out, or aborted. All statuses are enabled by default. The trigger payload includes full run details and metadata. |
 | **Actor task finished** | Fires when a selected Actor task run finishes. Same status filtering options as the Actor run finished trigger. Useful for monitoring scheduled or recurring task executions. |
 
@@ -55,7 +55,7 @@ To test the connector, you will need an Apify account. You can create one for fr
 ### Basic workflow: Run an Actor and get results
 
 1. Add the **Run Actor** action to your flow.
-2. Select an Actor from your recently used Actors or from the Apify Store.
+2. Select an Actor from your recently used Actors or from Apify Store.
 3. Provide the input JSON required by the Actor.
 4. Add the **Get dataset items** action.
 5. Use the **Default dataset ID** output from the Run Actor step as the Dataset parameter.
@@ -80,15 +80,15 @@ To test the connector, you will need an Apify account. You can create one for fr
 - The **Wait for Finish** parameter has a maximum of 60 seconds. For long-running Actors, use the **Actor run finished** trigger instead of waiting.
 - Dataset schemas are dynamically inferred from a sample item. They may not capture all possible fields if the dataset contains items with varying structures.
 - Key-value store record schemas are inferred from the record content. Binary records (images, PDFs) are returned as-is without schema inference.
-- The **Scrape single URL** action uses a fixed Actor (Web Scraper). For advanced scraping scenarios, use **Run Actor** with a specialized Actor from the Apify Store.
+- The **Scrape single URL** action uses a fixed Actor (Web Scraper). For advanced scraping scenarios, use **Run Actor** with a specialized Actor from Apify Store.
 - Memory allocation options range from 128 MB to 32 GB. Start with default settings to optimize costs.
 
 ## Common errors and remedies
 
 | Error | Remedy |
-|-------|--------|
+| --- | --- |
 | **Unable to authenticate** | Ensure you have an active Apify account. Try removing the connection and creating a new one. |
-| **Actor run returns FAILED status** | Check the Actor run logs in the Apify Console for detailed error messages. Verify the input matches the Actor's expected format. |
+| **Actor run returns FAILED status** | Check the Actor run logs in Apify Console for detailed error messages. Verify the input matches the Actor's expected format. |
 | **Dataset is empty after run completes** | Confirm the Actor run finished with SUCCEEDED status. The target website's structure may have changed. |
 | **Flow times out waiting for Actor** | Set "Wait for Finish" to 0 and use the "Actor run finished" trigger to handle long-running Actors asynchronously. |
 | **Webhook trigger not firing** | Verify the Actor or task ID is correct. Check that at least one event status is enabled. |
@@ -99,7 +99,7 @@ To test the connector, you will need an Apify account. You can create one for fr
 The connector itself is free. Apify charges for platform usage based on compute time and resources consumed. A free tier with monthly credits is included with every account. See [apify.com/pricing](https://apify.com/pricing) for details.
 
 **What are Actors?**
-Actors are serverless cloud programs that run on the Apify platform. They can perform web scraping, data extraction, AI automation, and more. Browse over 4,000 ready-made Actors at [apify.com/store](https://apify.com/store).
+Actors are serverless cloud programs that run on the Apify platform. They can perform web scraping, data extraction, AI automation, and more. Browse over 30,000 ready-made Actors at [apify.com/store](https://apify.com/store).
 
 **What are tasks?**
 Tasks are saved configurations for Actors. They store default input values so you can run an Actor with pre-set parameters without re-entering them each time.
@@ -108,7 +108,7 @@ Tasks are saved configurations for Actors. They store default input values so yo
 
 - [Apify documentation](https://docs.apify.com)
 - [Apify API reference](https://docs.apify.com/api/v2)
-- [Apify Store — browse Actors](https://apify.com/store)
+- [Apify Store - browse Actors](https://apify.com/store)
 - [Apify pricing](https://apify.com/pricing)
 - [Support and contact](https://apify.com/contact)
 - [Community forum](https://community.apify.com)


### PR DESCRIPTION
## Summary

Apify's content team reviewed `README.md` and `intro.md`. This PR applies their revisions.

## Changes

- Repositioning: *"full-stack web scraping and automation platform"* -> **"largest marketplace of tools for AI"**, Actor count 4k -> 30k.
- `intro.md`: new "For the Microsoft certification review team" section, new "Common errors and remedies" table.
- `README.md`: new "Common use cases" section. Removed stale hardcoded actor ID from the Scrape single URL section (now uses the virtual `/scrape-single-url` path per the cert-5000.2.6.2 fix).
- Rebuilt `ConnectorPackage.zip` with the updated `intro.md`.

No changes to swagger, apiProperties, script, or icon.

## Test plan

- [x] `scripts/validate.sh` - all policy checks pass.
- [x] `pwsh scripts/ConnectorPackageValidator.ps1 …` -> *"Validation successful."*